### PR TITLE
Fix bug with nested patterns rendering bound content

### DIFF
--- a/includes/class-pattern-builder-controller.php
+++ b/includes/class-pattern-builder-controller.php
@@ -364,9 +364,8 @@ class Pattern_Builder_Controller
 
 						if ( $pattern ) {
 
-							$attributes = [
-								'slug' => $pattern->name,
-							];
+							unset($attributes['ref']);
+							$attributes['slug'] = $pattern->name;
 
 							return 'wp:pattern ' . json_encode($attributes, JSON_UNESCAPED_SLASHES) . ' /-->';
 						}


### PR DESCRIPTION
When Theme Patterns are saved include the bound data in the markup.

When synced theme patterns are registered save a reference to them for easy lookup.

When synced theme patterns are rendered include the bound data in the re-rendered wp:block theme markup.