### PR TITLE
Clean up PatternEditor component after mode/tab removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pattern-builder",
-	"version": "0.1.1",
+	"version": "0.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pattern-builder",
-			"version": "0.1.1",
+			"version": "0.1.3",
 			"devDependencies": {
 				"@jest/globals": "^29.7.0",
 				"@wordpress/block-editor": "^14.18.0",

--- a/src/components/PatternEditor.js
+++ b/src/components/PatternEditor.js
@@ -21,7 +21,6 @@ import { useSelect, dispatch, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
 import { PatternDetails } from './PatternDetails';
-import PatternSearch from './PatternSearch';
 import { formatBlockMarkup, validateBlockMarkup } from '../utils/formatters';
 import BlockBindingsPanel from './BlockBindingsPanel';
 
@@ -166,11 +165,7 @@ export const PatternEditor = ({ pattern, onClose }) => {
 													<InserterLibrary />
 												</Panel>
 											)}
-											{tab.name === 'patterns' && (
-												<Panel>
-													<PatternSearch />
-												</Panel>
-											)}
+
 											{tab.name === 'bindings' && (
 												<Panel>
 													<BlockBindingsPanel />
@@ -197,19 +192,7 @@ export const PatternEditor = ({ pattern, onClose }) => {
 					/>
 				)}
 
-				{editorMode === 'code' && (
-					<div className="pattern-editor__code-placeholder">
-						{/* Placeholder for Code mode */}
-						<p>Code editor placeholder</p>
-					</div>
-				)}
 
-				{editorMode === 'style' && (
-					<div className="pattern-editor__style-placeholder">
-						{/* Placeholder for Style mode */}
-						<p>Style editor placeholder</p>
-					</div>
-				)}
 			</BlockEditorProvider>
 		</div>
 	);

--- a/tests/unit/PatternEditor.test.js
+++ b/tests/unit/PatternEditor.test.js
@@ -1,0 +1,73 @@
+/**
+ * Test for PatternEditor component cleanup
+ * 
+ * This test verifies that the PatternEditor component has been properly cleaned up
+ * after removing the 'code', 'style', and 'patterns' modes/tabs.
+ */
+
+describe('PatternEditor Component Cleanup', () => {
+	it('should not contain references to removed editor modes', () => {
+		// Read the PatternEditor component file
+		const fs = require('fs');
+		const path = require('path');
+		const filePath = path.join(__dirname, '../../src/components/PatternEditor.js');
+		const fileContent = fs.readFileSync(filePath, 'utf8');
+
+		// Check that removed modes are not referenced in conditional rendering
+		expect(fileContent).not.toMatch(/editorMode === 'code'/);
+		expect(fileContent).not.toMatch(/editorMode === 'style'/);
+		
+		// Check that removed tab is not referenced
+		expect(fileContent).not.toMatch(/tab\.name === 'patterns'/);
+		
+		// Check that PatternSearch import has been removed
+		expect(fileContent).not.toMatch(/import PatternSearch/);
+		
+		// Verify that only valid editor modes are present
+		expect(fileContent).toMatch(/editorMode === 'visual'/);
+		expect(fileContent).toMatch(/editorMode === 'markup'/);
+		
+		// Verify that only valid tabs are present
+		expect(fileContent).toMatch(/tab\.name === 'pattern'/);
+		expect(fileContent).toMatch(/tab\.name === 'block'/);
+		expect(fileContent).toMatch(/tab\.name === 'blocks'/);
+		expect(fileContent).toMatch(/tab\.name === 'bindings'/);
+	});
+
+	it('should have the correct tab configuration', () => {
+		const fs = require('fs');
+		const path = require('path');
+		const filePath = path.join(__dirname, '../../src/components/PatternEditor.js');
+		const fileContent = fs.readFileSync(filePath, 'utf8');
+
+		// Check that the tabs array contains only the expected tabs
+		const tabsMatch = fileContent.match(/tabs=\{(\[[\s\S]*?\])\}/);
+		if (tabsMatch) {
+			const tabsContent = tabsMatch[1];
+			
+			// Should contain these tabs
+			expect(tabsContent).toMatch(/name:\s*['"]pattern['"]/);
+			expect(tabsContent).toMatch(/name:\s*['"]block['"]/);
+			expect(tabsContent).toMatch(/name:\s*['"]blocks['"]/);
+			expect(tabsContent).toMatch(/name:\s*['"]bindings['"]/);
+			
+			// Should NOT contain these removed tabs
+			expect(tabsContent).not.toMatch(/name:\s*['"]patterns['"]/);
+		}
+	});
+
+	it('should have the correct toggle group options', () => {
+		const fs = require('fs');
+		const path = require('path');
+		const filePath = path.join(__dirname, '../../src/components/PatternEditor.js');
+		const fileContent = fs.readFileSync(filePath, 'utf8');
+
+		// Should contain visual and markup options
+		expect(fileContent).toMatch(/value="visual"/);
+		expect(fileContent).toMatch(/value="markup"/);
+		
+		// Should NOT contain code and style options
+		expect(fileContent).not.toMatch(/value="code"/);
+		expect(fileContent).not.toMatch(/value="style"/);
+	});
+});


### PR DESCRIPTION
## Summary

This PR cleans up the PatternEditor component by removing dead code that was left behind after recent commits that removed certain editor modes and tabs.

## Changes Made

- **Removed dead code for 'code' and 'style' editor modes**: These modes were removed from the ToggleGroupControl in recent commits, but the corresponding conditional rendering blocks were left in the code (lines 200-212). This created unreachable code that could cause confusion.

- **Removed unused 'patterns' tab conditional rendering**: The 'patterns' tab was also removed from the tabs configuration, but the conditional rendering for `tab.name === 'patterns'` was still present.

- **Removed unused PatternSearch import**: Since the 'patterns' tab was removed, the PatternSearch component is no longer used and its import has been removed.

- **Added comprehensive test**: Created a new test file `tests/unit/PatternEditor.test.js` that verifies the cleanup was done correctly and prevents regression by checking that:
  - Removed editor modes ('code', 'style') are not referenced in conditional rendering
  - Removed tabs ('patterns') are not referenced
  - Unused imports (PatternSearch) are removed
  - Only valid editor modes ('visual', 'markup') and tabs ('pattern', 'block', 'blocks', 'bindings') are present

## Testing

- All existing tests continue to pass
- New test specifically validates the cleanup and prevents future regression
- Code is cleaner and more maintainable

## Related Issues

Fixes #14

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup/refactoring
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

@pbking can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bac140bf71534daaad5f973909dc1a14)