### PR TITLE
Add namespacing to classes

### DIFF
--- a/includes/class-pattern-builder-abstract-pattern.php
+++ b/includes/class-pattern-builder-abstract-pattern.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace TwentyBellows\PatternBuilder;
+
 class Abstract_Pattern
 {
 	public $id;

--- a/includes/class-pattern-builder-admin.php
+++ b/includes/class-pattern-builder-admin.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace TwentyBellows\PatternBuilder;
+
 class Pattern_Builder_Admin {
 
     private const PAGE_SLUG = 'pattern-builder';

--- a/includes/class-pattern-builder-api.php
+++ b/includes/class-pattern-builder-api.php
@@ -1,5 +1,15 @@
 <?php
 
+namespace TwentyBellows\PatternBuilder;
+
+use WP_Block_Patterns_Registry;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+use WP_Query;
+use WP_REST_Blocks_Controller;
+use WP_Block_Editor_Context;
+
 require_once __DIR__ . '/class-pattern-builder-abstract-pattern.php';
 require_once __DIR__ . '/class-pattern-builder-controller.php';
 

--- a/includes/class-pattern-builder-controller.php
+++ b/includes/class-pattern-builder-controller.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace TwentyBellows\PatternBuilder;
+
+use WP_Error;
+use WP_Query;
+
 require_once __DIR__ . '/class-pattern-builder-abstract-pattern.php';
 require_once ABSPATH . 'wp-admin/includes/file.php';
 

--- a/includes/class-pattern-builder-editor.php
+++ b/includes/class-pattern-builder-editor.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace TwentyBellows\PatternBuilder;
+
 class Pattern_Builder_Editor {
 
     public function __construct() {

--- a/includes/class-pattern-builder-post-type.php
+++ b/includes/class-pattern-builder-post-type.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace TwentyBellows\PatternBuilder;
+
 class Pattern_Builder_Post_Type
 {
 	public function __construct()

--- a/includes/class-pattern-builder.php
+++ b/includes/class-pattern-builder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace TwentyBellows\PatternBuilder;
+
 require_once __DIR__ . '/licensing.php';
 require_once __DIR__ . '/class-pattern-builder-api.php';
 require_once __DIR__ . '/class-pattern-builder-admin.php';
@@ -38,6 +40,3 @@ class Pattern_Builder
         return self::$instance;
     }
 }
-
-// Automatically instantiate the class when the file is included.
-Pattern_Builder::get_instance();

--- a/pattern-builder.php
+++ b/pattern-builder.php
@@ -18,3 +18,8 @@ if (! defined('ABSPATH')) {
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/class-pattern-builder.php';
+
+use TwentyBellows\PatternBuilder\Pattern_Builder;
+
+// Initialize the plugin
+Pattern_Builder::get_instance();


### PR DESCRIPTION
This pull request introduces a namespace, `TwentyBellows\PatternBuilder`, across all relevant files in the project to improve code organization and avoid naming conflicts. 