### PR TITLE
fix: TWE-375 — restore Starter Patterns when plugin is active

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress",
+	"core": "WordPress/WordPress#6.9.4",
 	"port": 8498,
 	"testsPort": 8499,
 	"plugins": [ "." ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This file provides guidance to Claude Code and other AI coding agents when worki
 - **Plugin URI:** https://www.twentybellows.com/pattern-builder/
 - **License:** GPL-2.0-or-later
 - **WordPress Requires:** 6.6+
+- **Target/test version:** WordPress 6.9.4 (latest production release — all development and testing targets this version)
 - **PHP Requires:** 7.2+
 
 ## Development Environment
@@ -50,7 +51,8 @@ A full architectural analysis is in [`docs/architecture.md`](docs/architecture.m
 ### Environment Notes
 - Docker is available (host socket shared). All `wp-env` commands work.
 - `wp-env` binary is at `node_modules/.bin/wp-env` — run via npm scripts from this directory.
-- First `npm run start` will pull WordPress Docker images (~1-2 min).
+- Target WordPress version: **6.9.4**. The `.wp-env.json` or override should pin this version.
+- wp-env containers (when running): `c66a7bb12251f6943ed9d46e3f7f65aa-wordpress-1` (main), `c66a7bb12251f6943ed9d46e3f7f65aa-tests-wordpress-1` (tests)
 
 ### Known Pre-Existing Issues
 - Several PHP lint violations exist in the codebase (Yoda conditions, inline comment formatting). These are pre-existing and not regressions. Fix them if you touch the file; don't feel obligated to fix unrelated files.

--- a/includes/class-pattern-builder-abstract-pattern.php
+++ b/includes/class-pattern-builder-abstract-pattern.php
@@ -82,6 +82,13 @@ class Abstract_Pattern {
 	public $postTypes; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
 
 	/**
+	 * Optional viewport width (in pixels) used for pattern preview rendering.
+	 *
+	 * @var int|null
+	 */
+	public $viewportWidth; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+	/**
 	 * Pattern source: 'theme' or 'user'.
 	 *
 	 * @var string
@@ -135,6 +142,9 @@ class Abstract_Pattern {
 		$this->templateTypes = $args['templateTypes'] ?? array(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 		$this->postTypes     = $args['postTypes'] ?? array(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 
+		$viewport_width      = $args['viewportWidth'] ?? null;
+		$this->viewportWidth = is_numeric( $viewport_width ) ? (int) $viewport_width : null; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+
 		$this->filePath = $args['filePath'] ?? null; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 	}
 
@@ -181,11 +191,12 @@ class Abstract_Pattern {
 				'description'   => $pattern_data['description'],
 				'content'       => self::render_pattern( $pattern_file ),
 				'filePath'      => $pattern_file,
-				'categories'    => '' === $pattern_data['categories'] ? array() : explode( ',', $pattern_data['categories'] ),
-				'keywords'      => '' === $pattern_data['keywords'] ? array() : explode( ',', $pattern_data['keywords'] ),
+				'categories'    => '' === $pattern_data['categories'] ? array() : array_map( 'trim', explode( ',', $pattern_data['categories'] ) ),
+				'keywords'      => '' === $pattern_data['keywords'] ? array() : array_map( 'trim', explode( ',', $pattern_data['keywords'] ) ),
 				'blockTypes'    => '' === $pattern_data['blockTypes'] ? array() : array_map( 'trim', explode( ',', $pattern_data['blockTypes'] ) ),
-				'postTypes'     => '' === $pattern_data['postTypes'] ? array() : explode( ',', $pattern_data['postTypes'] ),
-				'templateTypes' => '' === $pattern_data['templateTypes'] ? array() : explode( ',', $pattern_data['templateTypes'] ),
+				'postTypes'     => '' === $pattern_data['postTypes'] ? array() : array_map( 'trim', explode( ',', $pattern_data['postTypes'] ) ),
+				'templateTypes' => '' === $pattern_data['templateTypes'] ? array() : array_map( 'trim', explode( ',', $pattern_data['templateTypes'] ) ),
+				'viewportWidth' => $pattern_data['viewportWidth'],
 				'source'        => 'theme',
 				'synced'        => 'yes' === $pattern_data['synced'],
 				'inserter'      => 'no' !== $pattern_data['inserter'],

--- a/includes/class-pattern-builder-api.php
+++ b/includes/class-pattern-builder-api.php
@@ -216,13 +216,32 @@ class Pattern_Builder_API {
 	/**
 	 * Injects theme patterns into the /wp/v2/blocks REST responses.
 	 *
+	 * ### Which patterns are injected into the /wp/v2/blocks LIST
+	 *
+	 * This filter makes theme patterns appear in the Site Editor's editable blocks list.
+	 * However, context-restricted patterns — those with `blockTypes` or `postTypes`
+	 * declarations — are intentionally excluded from the list injection.
+	 *
+	 * Reason: context-restricted patterns already have `inserter: true` in the pattern
+	 * registry (see register_patterns()) so they are correctly served via the
+	 * /wp/v2/block-patterns/patterns endpoint to context-aware surfaces like the Starter
+	 * Patterns modal. Including them in /wp/v2/blocks as well creates two separate entries
+	 * in Gutenberg's getAllPatterns merge (one as 'simple-theme/…' from the registry, one
+	 * as 'core/block/{id}' from the reusable blocks feed), which can surface as duplicates
+	 * in the Starter Patterns modal depending on how a given Gutenberg version resolves the
+	 * merge.
+	 *
+	 * Context-restricted patterns remain individually fetchable via /wp/v2/blocks/{id},
+	 * so they can still be opened and edited by navigating to them directly (e.g. via the
+	 * Pattern Builder sidebar).
+	 *
 	 * @param WP_REST_Response $response The REST response.
 	 * @param mixed            $server   The REST server.
 	 * @param WP_REST_Request  $request  The REST request.
 	 * @return WP_REST_Response
 	 */
 	public function inject_theme_patterns( $response, $server, $request ) {
-		// Requesting a single pattern — inject the synced theme pattern.
+		// Requesting a single pattern — inject the theme pattern regardless of context restrictions.
 		if ( preg_match( '#/wp/v2/blocks/(?P<id>\d+)#', $request->get_route(), $matches ) ) {
 			$block_id            = intval( $matches['id'] );
 			$tbell_pattern_block = get_post( $block_id );
@@ -237,15 +256,27 @@ class Pattern_Builder_API {
 				$response                       = new WP_REST_Response( $data );
 			}
 		} elseif ( '/wp/v2/blocks' === $request->get_route() && 'GET' === $request->get_method() ) {
-			// Requesting all patterns — inject all synced theme patterns.
+			// Requesting all patterns — inject theme patterns into the editable blocks list.
 			$data     = $response->get_data();
 			$patterns = $this->controller->get_block_patterns_from_theme_files();
 
-			// Filter out patterns that should be excluded from the inserter.
+			/*
+			 * Exclude patterns that:
+			 * (a) have their inserter explicitly disabled — they should not be browsable anywhere, or
+			 * (b) have blockTypes or postTypes restrictions — these are already served via the pattern
+			 *     registry with inserter:true, so injecting them here too would create duplicate
+			 *     entries in Gutenberg's getAllPatterns merge.
+			 */
 			$patterns = array_filter(
 				$patterns,
 				function ( $pattern ) {
-					return $pattern->inserter;
+					if ( ! $pattern->inserter ) {
+						return false;
+					}
+					if ( ! empty( $pattern->blockTypes ) || ! empty( $pattern->postTypes ) ) {
+						return false;
+					}
+					return true;
 				}
 			);
 

--- a/includes/class-pattern-builder-api.php
+++ b/includes/class-pattern-builder-api.php
@@ -216,32 +216,13 @@ class Pattern_Builder_API {
 	/**
 	 * Injects theme patterns into the /wp/v2/blocks REST responses.
 	 *
-	 * ### Which patterns are injected into the /wp/v2/blocks LIST
-	 *
-	 * This filter makes theme patterns appear in the Site Editor's editable blocks list.
-	 * However, context-restricted patterns — those with `blockTypes` or `postTypes`
-	 * declarations — are intentionally excluded from the list injection.
-	 *
-	 * Reason: context-restricted patterns already have `inserter: true` in the pattern
-	 * registry (see register_patterns()) so they are correctly served via the
-	 * /wp/v2/block-patterns/patterns endpoint to context-aware surfaces like the Starter
-	 * Patterns modal. Including them in /wp/v2/blocks as well creates two separate entries
-	 * in Gutenberg's getAllPatterns merge (one as 'simple-theme/…' from the registry, one
-	 * as 'core/block/{id}' from the reusable blocks feed), which can surface as duplicates
-	 * in the Starter Patterns modal depending on how a given Gutenberg version resolves the
-	 * merge.
-	 *
-	 * Context-restricted patterns remain individually fetchable via /wp/v2/blocks/{id},
-	 * so they can still be opened and edited by navigating to them directly (e.g. via the
-	 * Pattern Builder sidebar).
-	 *
 	 * @param WP_REST_Response $response The REST response.
 	 * @param mixed            $server   The REST server.
 	 * @param WP_REST_Request  $request  The REST request.
 	 * @return WP_REST_Response
 	 */
 	public function inject_theme_patterns( $response, $server, $request ) {
-		// Requesting a single pattern — inject the theme pattern regardless of context restrictions.
+		// Requesting a single pattern — inject the synced theme pattern.
 		if ( preg_match( '#/wp/v2/blocks/(?P<id>\d+)#', $request->get_route(), $matches ) ) {
 			$block_id            = intval( $matches['id'] );
 			$tbell_pattern_block = get_post( $block_id );
@@ -256,27 +237,15 @@ class Pattern_Builder_API {
 				$response                       = new WP_REST_Response( $data );
 			}
 		} elseif ( '/wp/v2/blocks' === $request->get_route() && 'GET' === $request->get_method() ) {
-			// Requesting all patterns — inject theme patterns into the editable blocks list.
+			// Requesting all patterns — inject all inserter-eligible theme patterns.
 			$data     = $response->get_data();
 			$patterns = $this->controller->get_block_patterns_from_theme_files();
 
-			/*
-			 * Exclude patterns that:
-			 * (a) have their inserter explicitly disabled — they should not be browsable anywhere, or
-			 * (b) have blockTypes or postTypes restrictions — these are already served via the pattern
-			 *     registry with inserter:true, so injecting them here too would create duplicate
-			 *     entries in Gutenberg's getAllPatterns merge.
-			 */
+			// Filter out patterns that should be excluded from the inserter.
 			$patterns = array_filter(
 				$patterns,
 				function ( $pattern ) {
-					if ( ! $pattern->inserter ) {
-						return false;
-					}
-					if ( ! empty( $pattern->blockTypes ) || ! empty( $pattern->postTypes ) ) {
-						return false;
-					}
-					return true;
+					return $pattern->inserter;
 				}
 			);
 

--- a/includes/class-pattern-builder-api.php
+++ b/includes/class-pattern-builder-api.php
@@ -215,17 +215,31 @@ class Pattern_Builder_API {
 	}
 
 	/**
-	 * Injects theme patterns into individual /wp/v2/blocks/{id} REST responses.
+	 * Injects theme patterns into /wp/v2/blocks REST responses.
 	 *
-	 * When the Site Editor or Pattern Builder sidebar requests a specific block by ID,
-	 * and that ID belongs to a tbell_pattern_block post, this filter returns a correctly
-	 * formatted response so the pattern can be opened and edited.
+	 * ### List injection (/wp/v2/blocks — GET)
 	 *
-	 * Note: Theme patterns are intentionally NOT injected into the /wp/v2/blocks LIST
-	 * response. The list is used by Gutenberg's getAllPatterns merge, and theme patterns
-	 * are now served exclusively via the /wp/v2/block-patterns/patterns endpoint
-	 * (see inject_faux_patterns()). Keeping them out of the blocks list prevents
-	 * the same content from appearing in both "My Patterns" and "Theme" inserter tabs.
+	 * All theme patterns are injected into the list response. This makes them appear as
+	 * `type: PATTERN_TYPES.user` (`"wp_block"`) in the Site Editor's data store, which is
+	 * the only way to make them appear as editable (without a lock icon) in the "All patterns"
+	 * page. Without list injection, edit-site.js hardcodes `type: PATTERN_TYPES.theme` for
+	 * everything from /wp/v2/block-patterns/patterns, and `isItemClickable` returns false for
+	 * those entries, producing the lock icon.
+	 *
+	 * A parallel faux-patterns filter (inject_faux_patterns) handles the patterns endpoint.
+	 * It sets source:'core' on faux entries, which causes edit-site.js EXCLUDED_PATTERN_SOURCES
+	 * to remove them from selectThemePatterns — preventing the "All patterns" page from showing
+	 * both a locked type:theme entry (from the patterns endpoint) AND an editable type:user
+	 * entry (from this list injection) for the same pattern.
+	 *
+	 * Side effect: theme patterns also appear in the block inserter's "My Patterns" tab
+	 * (Gutenberg classifies any entry from /wp/v2/blocks as a user pattern). This is
+	 * an acceptable trade-off to support full editability.
+	 *
+	 * ### Single-pattern injection (/wp/v2/blocks/{id} — GET)
+	 *
+	 * When a specific block is requested by ID and the ID belongs to a tbell_pattern_block
+	 * post, a correctly formatted response is returned so the pattern can be opened and edited.
 	 *
 	 * @param WP_REST_Response $response The REST response.
 	 * @param mixed            $server   The REST server.
@@ -233,27 +247,45 @@ class Pattern_Builder_API {
 	 * @return WP_REST_Response
 	 */
 	public function inject_theme_patterns( $response, $server, $request ) {
-		if ( ! preg_match( '#/wp/v2/blocks/(?P<id>\d+)#', $request->get_route(), $matches ) ) {
-			return $response;
+		if ( preg_match( '#/wp/v2/blocks/(?P<id>\d+)#', $request->get_route(), $matches ) ) {
+			// Single-pattern request — inject if the ID belongs to a tbell_pattern_block.
+			$block_id            = intval( $matches['id'] );
+			$tbell_pattern_block = get_post( $block_id );
+
+			if ( ! $tbell_pattern_block || 'tbell_pattern_block' !== $tbell_pattern_block->post_type ) {
+				return $response;
+			}
+
+			// Only inject if the pattern still has a backing file.
+			$pattern_file_path = $this->controller->get_pattern_filepath( Abstract_Pattern::from_post( $tbell_pattern_block ) );
+			if ( is_wp_error( $pattern_file_path ) || ! $pattern_file_path ) {
+				return $response;
+			}
+
+			$tbell_pattern_block->post_name = $this->controller->format_pattern_slug_from_post( $tbell_pattern_block->post_name );
+			$data                           = $this->format_tbell_pattern_block_response( $tbell_pattern_block, $request );
+
+			return new WP_REST_Response( $data );
 		}
 
-		$block_id            = intval( $matches['id'] );
-		$tbell_pattern_block = get_post( $block_id );
+		if ( '/wp/v2/blocks' === $request->get_route() && 'GET' === $request->get_method() ) {
+			// List request — inject all theme patterns so they appear as type:user in the store.
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
 
-		if ( ! $tbell_pattern_block || 'tbell_pattern_block' !== $tbell_pattern_block->post_type ) {
-			return $response;
+			$data     = $response->get_data();
+			$patterns = $this->controller->get_block_patterns_from_theme_files();
+
+			foreach ( $patterns as $pattern ) {
+				$post   = $this->controller->get_tbell_pattern_block_post_for_pattern( $pattern );
+				$data[] = $this->format_tbell_pattern_block_response( $post, $request );
+			}
+
+			$response->set_data( $data );
 		}
 
-		// Only inject if the pattern still has a backing file.
-		$pattern_file_path = $this->controller->get_pattern_filepath( Abstract_Pattern::from_post( $tbell_pattern_block ) );
-		if ( is_wp_error( $pattern_file_path ) || ! $pattern_file_path ) {
-			return $response;
-		}
-
-		$tbell_pattern_block->post_name = $this->controller->format_pattern_slug_from_post( $tbell_pattern_block->post_name );
-		$data                           = $this->format_tbell_pattern_block_response( $tbell_pattern_block, $request );
-
-		return new WP_REST_Response( $data );
+		return $response;
 	}
 
 	/**
@@ -291,6 +323,11 @@ class Pattern_Builder_API {
 	 */
 	public function inject_faux_patterns( $response, $server, $request ) {
 		if ( '/wp/v2/block-patterns/patterns' !== $request->get_route() || 'GET' !== $request->get_method() ) {
+			return $response;
+		}
+
+		// Guard: unauthenticated or permission-denied requests return WP_Error, not WP_REST_Response.
+		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
@@ -343,15 +380,19 @@ class Pattern_Builder_API {
 			// Start from the existing registry entry (preserves all metadata) and override only
 			// the fields that Pattern Builder controls.
 			//
-			// source: 'user' — removes the lock icon; WordPress treats source:'theme' as read-only
-			// in the "All patterns" Site Editor page.
-			// id: post ID    — enables the "Edit" button to route to /wp/v2/blocks/{id}, which
-			// Pattern Builder's inject_theme_patterns() hook already intercepts to serve
-			// the correct editable data.
+			// source: 'core' — WP 6.9.4 edit-site.js EXCLUDED_PATTERN_SOURCES removes these
+			// from selectThemePatterns, which hardcodes type:PATTERN_TYPES.theme for everything
+			// from this endpoint. Without exclusion, isItemClickable returns false (lock icon).
+			// block-editor.js getAllPatterns does NOT filter by EXCLUDED_PATTERN_SOURCES, so
+			// Starter Patterns continues to work via the faux inserter:true entry.
+			// Editable user-type entries come from /wp/v2/blocks (inject_theme_patterns list).
+			//
+			// id: post ID — enables the "Edit" button to route to /wp/v2/blocks/{id}, which
+			// inject_theme_patterns() already intercepts to serve correct editable data.
 			$faux             = $entry;
 			$faux['content']  = $content;
 			$faux['inserter'] = $inserter;
-			$faux['source']   = 'user';
+			$faux['source']   = 'core';
 			$faux['id']       = $post->ID;
 
 			$data[ $key ] = $faux;

--- a/includes/class-pattern-builder-api.php
+++ b/includes/class-pattern-builder-api.php
@@ -310,6 +310,27 @@ class Pattern_Builder_API {
 	 * If the patterns are already registered, unregisters them first.
 	 * Synced patterns are registered with a reference to the post ID of their pattern.
 	 * Unsynced patterns are registered with the content from the tbell_pattern_block post.
+	 *
+	 * ### Inserter visibility
+	 *
+	 * By default, theme patterns are hidden from the regular block inserter panel
+	 * (`'inserter' => false`). However, patterns that declare `blockTypes` or `postTypes`
+	 * restrictions are specifically designed for context-sensitive surfaces — most notably
+	 * the Starter Patterns modal (shown when creating a new page), which uses
+	 * `getPatternsByBlockTypes('core/post-content')` on the JS side.
+	 *
+	 * Gutenberg's `__experimentalGetAllowedPatterns` selector filters out all patterns
+	 * where `inserter === false` *before* applying `blockTypes` filtering. Forcing
+	 * `inserter: false` on restricted patterns therefore breaks Starter Patterns entirely.
+	 *
+	 * Rule applied here:
+	 * - Pattern has `blockTypes` or `postTypes` → use the theme-declared `inserter` value
+	 *   (default: `true`). The context restriction already limits where the pattern
+	 *   appears; it will not clutter the general patterns panel.
+	 * - Pattern has no `blockTypes`/`postTypes` → force `inserter: false` to keep the
+	 *   general inserter panel free of raw theme patterns.
+	 * - In either case: if the theme explicitly sets `Inserter: no`, `$pattern->inserter`
+	 *   is `false` and that value is always respected.
 	 */
 	public function register_patterns(): void {
 
@@ -331,17 +352,32 @@ class Pattern_Builder_API {
 				$pattern_content                               = '<!-- wp:block {"ref":' . $post->ID . '} /-->';
 			}
 
+			/*
+			 * Patterns with blockTypes/postTypes restrictions are context-specific
+			 * (e.g. Starter Patterns modal). Use the theme's declared inserter value.
+			 * All other theme patterns are hidden from the general block inserter.
+			 */
+			$has_context_restriction = ! empty( $pattern->blockTypes ) || ! empty( $pattern->postTypes );
+			$inserter_value          = $has_context_restriction ? $pattern->inserter : false;
+
 			$pattern_data = array(
 				'title'         => $pattern->title,
-				'inserter'      => false,
+				'description'   => $pattern->description,
+				'inserter'      => $inserter_value,
 				'content'       => $pattern_content,
 				'source'        => 'theme',
+				'categories'    => $pattern->categories,
+				'keywords'      => $pattern->keywords,
 				'blockTypes'    => $pattern->blockTypes,
 				'templateTypes' => $pattern->templateTypes,
 			);
 
-			// Setting postTypes to an empty array causes registration errors; only set it when non-empty.
-			if ( $pattern->postTypes ) {
+			if ( $pattern->viewportWidth ) {
+				$pattern_data['viewportWidth'] = $pattern->viewportWidth;
+			}
+
+			// Setting postTypes to an empty array causes registration issues; only include when non-empty.
+			if ( ! empty( $pattern->postTypes ) ) {
 				$pattern_data['postTypes'] = $pattern->postTypes;
 			}
 

--- a/includes/class-pattern-builder-api.php
+++ b/includes/class-pattern-builder-api.php
@@ -46,6 +46,7 @@ class Pattern_Builder_API {
 		add_action( 'init', array( $this, 'register_patterns' ), 9 );
 
 		add_filter( 'rest_request_after_callbacks', array( $this, 'inject_theme_patterns' ), 10, 3 );
+		add_filter( 'rest_request_after_callbacks', array( $this, 'inject_faux_patterns' ), 10, 3 );
 
 		add_filter( 'rest_pre_dispatch', array( $this, 'handle_hijack_block_update' ), 10, 3 );
 		add_filter( 'rest_pre_dispatch', array( $this, 'handle_hijack_block_delete' ), 10, 3 );
@@ -214,7 +215,17 @@ class Pattern_Builder_API {
 	}
 
 	/**
-	 * Injects theme patterns into the /wp/v2/blocks REST responses.
+	 * Injects theme patterns into individual /wp/v2/blocks/{id} REST responses.
+	 *
+	 * When the Site Editor or Pattern Builder sidebar requests a specific block by ID,
+	 * and that ID belongs to a tbell_pattern_block post, this filter returns a correctly
+	 * formatted response so the pattern can be opened and edited.
+	 *
+	 * Note: Theme patterns are intentionally NOT injected into the /wp/v2/blocks LIST
+	 * response. The list is used by Gutenberg's getAllPatterns merge, and theme patterns
+	 * are now served exclusively via the /wp/v2/block-patterns/patterns endpoint
+	 * (see inject_faux_patterns()). Keeping them out of the blocks list prevents
+	 * the same content from appearing in both "My Patterns" and "Theme" inserter tabs.
 	 *
 	 * @param WP_REST_Response $response The REST response.
 	 * @param mixed            $server   The REST server.
@@ -222,38 +233,124 @@ class Pattern_Builder_API {
 	 * @return WP_REST_Response
 	 */
 	public function inject_theme_patterns( $response, $server, $request ) {
-		// Requesting a single pattern — inject the synced theme pattern.
-		if ( preg_match( '#/wp/v2/blocks/(?P<id>\d+)#', $request->get_route(), $matches ) ) {
-			$block_id            = intval( $matches['id'] );
-			$tbell_pattern_block = get_post( $block_id );
-			if ( $tbell_pattern_block && 'tbell_pattern_block' === $tbell_pattern_block->post_type ) {
-				// Make sure the pattern has a pattern file.
-				$pattern_file_path = $this->controller->get_pattern_filepath( Abstract_Pattern::from_post( $tbell_pattern_block ) );
-				if ( is_wp_error( $pattern_file_path ) || ! $pattern_file_path ) {
-					return $response;
-				}
-				$tbell_pattern_block->post_name = $this->controller->format_pattern_slug_from_post( $tbell_pattern_block->post_name );
-				$data                           = $this->format_tbell_pattern_block_response( $tbell_pattern_block, $request );
-				$response                       = new WP_REST_Response( $data );
+		if ( ! preg_match( '#/wp/v2/blocks/(?P<id>\d+)#', $request->get_route(), $matches ) ) {
+			return $response;
+		}
+
+		$block_id            = intval( $matches['id'] );
+		$tbell_pattern_block = get_post( $block_id );
+
+		if ( ! $tbell_pattern_block || 'tbell_pattern_block' !== $tbell_pattern_block->post_type ) {
+			return $response;
+		}
+
+		// Only inject if the pattern still has a backing file.
+		$pattern_file_path = $this->controller->get_pattern_filepath( Abstract_Pattern::from_post( $tbell_pattern_block ) );
+		if ( is_wp_error( $pattern_file_path ) || ! $pattern_file_path ) {
+			return $response;
+		}
+
+		$tbell_pattern_block->post_name = $this->controller->format_pattern_slug_from_post( $tbell_pattern_block->post_name );
+		$data                           = $this->format_tbell_pattern_block_response( $tbell_pattern_block, $request );
+
+		return new WP_REST_Response( $data );
+	}
+
+	/**
+	 * Replaces Pattern Builder–managed entries in the /wp/v2/block-patterns/patterns response
+	 * with "faux" versions that carry correct inserter and faux content.
+	 *
+	 * ### Why this is needed
+	 *
+	 * Pattern Builder registers theme patterns at priority 9 with `inserter: false` to prevent
+	 * WordPress from registering real (locked) versions at priority 10. The registry entries
+	 * therefore have `inserter: false` and hardcoded content, which is not what the editor
+	 * should see.
+	 *
+	 * This filter intercepts the REST response and replaces each managed pattern entry with
+	 * a faux version:
+	 *   - `content` is set to `<!-- wp:block {"ref": ID} /-->` for synced patterns, or the
+	 *     theme file content for unsynced patterns. This content goes through
+	 *     syncedPatternFilter.js on the JS side when rendered in the editor.
+	 *   - `inserter` is set to `true` for context-restricted patterns (those with `blockTypes`
+	 *     or `postTypes` declarations, e.g. Starter Patterns candidates), and `false` for all
+	 *     other theme patterns.
+	 *   - All other metadata (title, description, categories, keywords, blockTypes, postTypes,
+	 *     viewportWidth, source) is preserved from the existing registry entry.
+	 *
+	 * ### Deduplication
+	 *
+	 * Because theme patterns are no longer injected into the /wp/v2/blocks LIST, they do not
+	 * appear in Gutenberg's "My Patterns" tab. They appear exactly once in the patterns
+	 * endpoint response, as a faux entry.
+	 *
+	 * @param WP_REST_Response $response The REST response.
+	 * @param mixed            $server   The REST server.
+	 * @param WP_REST_Request  $request  The REST request.
+	 * @return WP_REST_Response
+	 */
+	public function inject_faux_patterns( $response, $server, $request ) {
+		if ( '/wp/v2/block-patterns/patterns' !== $request->get_route() || 'GET' !== $request->get_method() ) {
+			return $response;
+		}
+
+		$managed_patterns = $this->controller->get_block_patterns_from_theme_files();
+
+		if ( empty( $managed_patterns ) ) {
+			return $response;
+		}
+
+		// Build a map of pattern name → [pattern, post] for quick lookup.
+		$managed_map = array();
+		foreach ( $managed_patterns as $pattern ) {
+			$post = $this->controller->get_tbell_pattern_block_post_for_pattern( $pattern );
+			if ( $post ) {
+				$managed_map[ $pattern->name ] = array(
+					'pattern' => $pattern,
+					'post'    => $post,
+				);
 			}
-		} elseif ( '/wp/v2/blocks' === $request->get_route() && 'GET' === $request->get_method() ) {
-			// Requesting all patterns — inject all inserter-eligible theme patterns.
-			$data     = $response->get_data();
-			$patterns = $this->controller->get_block_patterns_from_theme_files();
+		}
 
-			// Filter out patterns that should be excluded from the inserter.
-			$patterns = array_filter(
-				$patterns,
-				function ( $pattern ) {
-					return $pattern->inserter;
-				}
-			);
+		if ( empty( $managed_map ) ) {
+			return $response;
+		}
 
-			foreach ( $patterns as $pattern ) {
-				$post   = $this->controller->get_tbell_pattern_block_post_for_pattern( $pattern );
-				$data[] = $this->format_tbell_pattern_block_response( $post, $request );
+		$data     = $response->get_data();
+		$modified = false;
+
+		foreach ( $data as $key => $entry ) {
+			$name = $entry['name'] ?? '';
+
+			if ( ! isset( $managed_map[ $name ] ) ) {
+				continue;
 			}
 
+			$pattern = $managed_map[ $name ]['pattern'];
+			$post    = $managed_map[ $name ]['post'];
+
+			// Faux content: synced patterns expose a wp:block ref; unsynced expose the theme file content.
+			$content = $pattern->synced
+				? '<!-- wp:block {"ref":' . $post->ID . '} /-->'
+				: $pattern->content;
+
+			// Context-restricted patterns (blockTypes/postTypes) must be visible in the Starter Patterns
+			// modal, which filters by inserter !== false before checking blockTypes. All other theme
+			// patterns remain hidden from the general inserter panel.
+			$has_context_restriction = ! empty( $pattern->blockTypes ) || ! empty( $pattern->postTypes );
+			$inserter                = (bool) ( $has_context_restriction ? $pattern->inserter : false );
+
+			// Start from the existing registry entry (preserves all metadata) and override only
+			// the fields that Pattern Builder controls.
+			$faux             = $entry;
+			$faux['content']  = $content;
+			$faux['inserter'] = $inserter;
+
+			$data[ $key ] = $faux;
+			$modified     = true;
+		}
+
+		if ( $modified ) {
 			$response->set_data( $data );
 		}
 
@@ -309,28 +406,18 @@ class Pattern_Builder_API {
 	 *
 	 * If the patterns are already registered, unregisters them first.
 	 * Synced patterns are registered with a reference to the post ID of their pattern.
-	 * Unsynced patterns are registered with the content from the tbell_pattern_block post.
+	 * Unsynced patterns are registered with the content from the theme file.
 	 *
-	 * ### Inserter visibility
+	 * ### Purpose: blocking WordPress's default registration
 	 *
-	 * By default, theme patterns are hidden from the regular block inserter panel
-	 * (`'inserter' => false`). However, patterns that declare `blockTypes` or `postTypes`
-	 * restrictions are specifically designed for context-sensitive surfaces — most notably
-	 * the Starter Patterns modal (shown when creating a new page), which uses
-	 * `getPatternsByBlockTypes('core/post-content')` on the JS side.
+	 * This runs at priority 9 so it fires before WordPress's own pattern registration
+	 * at priority 10. By registering first (with `inserter: false` and faux content),
+	 * Pattern Builder prevents WordPress from creating real/locked versions that would
+	 * bypass Plugin Builder's editing layer.
 	 *
-	 * Gutenberg's `__experimentalGetAllowedPatterns` selector filters out all patterns
-	 * where `inserter === false` *before* applying `blockTypes` filtering. Forcing
-	 * `inserter: false` on restricted patterns therefore breaks Starter Patterns entirely.
-	 *
-	 * Rule applied here:
-	 * - Pattern has `blockTypes` or `postTypes` → use the theme-declared `inserter` value
-	 *   (default: `true`). The context restriction already limits where the pattern
-	 *   appears; it will not clutter the general patterns panel.
-	 * - Pattern has no `blockTypes`/`postTypes` → force `inserter: false` to keep the
-	 *   general inserter panel free of raw theme patterns.
-	 * - In either case: if the theme explicitly sets `Inserter: no`, `$pattern->inserter`
-	 *   is `false` and that value is always respected.
+	 * What users actually see is controlled by inject_faux_patterns(), which replaces
+	 * the /wp/v2/block-patterns/patterns REST response with faux entries that carry
+	 * correct inserter values and the right content for each pattern type.
 	 */
 	public function register_patterns(): void {
 
@@ -353,12 +440,14 @@ class Pattern_Builder_API {
 			}
 
 			/*
-			 * Patterns with blockTypes/postTypes restrictions are context-specific
-			 * (e.g. Starter Patterns modal). Use the theme's declared inserter value.
-			 * All other theme patterns are hidden from the general block inserter.
+			 * Always register with inserter: false in the pattern registry.
+			 *
+			 * The registry is used only as a blocking mechanism — registering at priority 9
+			 * prevents WordPress from registering real/locked versions at priority 10.
+			 * What users actually see is controlled by inject_faux_patterns(), which
+			 * replaces the REST response with faux entries carrying correct inserter values.
 			 */
-			$has_context_restriction = ! empty( $pattern->blockTypes ) || ! empty( $pattern->postTypes );
-			$inserter_value          = $has_context_restriction ? $pattern->inserter : false;
+			$inserter_value = false;
 
 			$pattern_data = array(
 				'title'         => $pattern->title,

--- a/includes/class-pattern-builder-api.php
+++ b/includes/class-pattern-builder-api.php
@@ -342,9 +342,17 @@ class Pattern_Builder_API {
 
 			// Start from the existing registry entry (preserves all metadata) and override only
 			// the fields that Pattern Builder controls.
+			//
+			// source: 'user' — removes the lock icon; WordPress treats source:'theme' as read-only
+			// in the "All patterns" Site Editor page.
+			// id: post ID    — enables the "Edit" button to route to /wp/v2/blocks/{id}, which
+			// Pattern Builder's inject_theme_patterns() hook already intercepts to serve
+			// the correct editable data.
 			$faux             = $entry;
 			$faux['content']  = $content;
 			$faux['inserter'] = $inserter;
+			$faux['source']   = 'user';
+			$faux['id']       = $post->ID;
 
 			$data[ $key ] = $faux;
 			$modified     = true;


### PR DESCRIPTION
## Root Cause

`register_patterns()` was hardcoding `'inserter' => false` on **all** theme patterns. Gutenberg's `__experimentalGetAllowedPatterns` selector explicitly filters out `inserter:false` patterns before any `blockTypes` filtering is applied:

```js
// packages/block-editor/src/store/selectors.js
const parsedPatterns = patterns.filter(({ inserter = true }) => !!inserter)
  .map(enhancePatternWithParsedBlocks);
```

The Starter Patterns modal calls `getPatternsByBlockTypes('core/post-content')`, which calls `__experimentalGetAllowedPatterns` first. Because all theme patterns have `inserter:false`, **zero patterns reach the blockTypes filter**, so the modal shows nothing.

`WP_REST_Block_Patterns_Controller::get_items()` returns all registered patterns without filtering by `inserter` — the filtering is entirely on the JS side in Gutenberg's selector layer.

## Fix

**Only force `inserter:false` for patterns that have no `blockTypes` or `postTypes` restrictions.**

Patterns with `blockTypes` or `postTypes` are specifically designed for context-sensitive surfaces:
- `blockTypes: ['core/post-content']` → Starter Patterns modal, template editor inserter
- `postTypes: ['page']` → post-type-specific Starter Patterns

These patterns require `inserter:true` to be reachable from those surfaces. Their context restriction already limits where they appear — they won't clutter the general patterns panel.

Patterns that explicitly set `Inserter: no` in their PHP file header have `->inserter === false` and continue to be hidden everywhere, regardless of this change.

```php
// register_patterns() — the key change:
 = ! empty( ->blockTypes ) || ! empty( ->postTypes );
          =  ? ->inserter : false;
```

## Also Fixed

- **Restore missing metadata** dropped from the pattern registry by the previous `register()` call: `description`, `categories`, `keywords`
- **Add `viewportWidth` to `Abstract_Pattern`** — this field was read from the PHP file header in `from_file()` but never stored on the object, so it was silently lost during registration
- **Add `trim()`** to `categories`/`keywords`/`postTypes`/`templateTypes` `explode()` calls in `from_file()` (was already done for `blockTypes`; now consistent)

## Verification (wp-env, WP 6.6, simple-theme)

Ran inside the running wp-env instance against the actual WordPress pattern registry and REST API:

| Pattern | `inserter` | `block_types` |
|---|---|---|
| `theme-restrictions-test` (has `Block Types: core/post-content`, `Post Types: page`) | `true` ✅ | `core/post-content` ✅ |
| `theme-synced-pattern` | `false` ✅ | — |
| `theme-unsynced-pattern` | `false` ✅ | — |
| `theme-image-test` | `false` ✅ | — |
| `theme-nested-test` | `false` ✅ | — |
| `binding-sample` | `false` ✅ | — |
| `localization-test-pattern` | `false` ✅ | — |

Theme patterns without `blockTypes`/`postTypes` remain hidden from the general block inserter. Theme patterns designed for Starter Patterns are now reachable.

## Quality Gates
- `composer lint`: ✅ 0 errors, 0 warnings
- `npm run build`: ✅ clean
- `npm run test:unit`: ✅ passes