### PR TITLE
Design tokens: carry preset defaults on upload, resolve them on download

### DIFF
--- a/includes/class-pattern-builder-cloud-controller.php
+++ b/includes/class-pattern-builder-cloud-controller.php
@@ -48,6 +48,7 @@ class Pattern_Builder_Cloud_Controller {
 			'/cloud/upload'           => array( 'POST', 'upload' ),
 			'/cloud/download'         => array( 'POST', 'download' ),
 			'/cloud/generate'         => array( 'POST', 'generate' ),
+			'/cloud/tokens/check'     => array( 'POST', 'tokens_check' ),
 		);
 
 		foreach ( $routes as $route => $handler ) {
@@ -294,6 +295,20 @@ class Pattern_Builder_Cloud_Controller {
 			return $pbp;
 		}
 
+		/*
+		 * Design tokens the pattern references but this site doesn't define
+		 * get written to the home the user chose (§4a). Definitions this
+		 * site already has always win — those tokens are never touched.
+		 */
+		$tokens_written    = array();
+		$token_destination = $request->get_param( 'tokenDestination' );
+		if ( ! empty( $pbp['tokens'] ) && in_array( $token_destination, array( 'user', 'theme' ), true ) ) {
+			$tokens_written = Pattern_Builder_Cloud_Tokens::apply( $pbp['tokens'], $token_destination );
+			if ( is_wp_error( $tokens_written ) ) {
+				return $tokens_written;
+			}
+		}
+
 		$porter = new Pattern_Builder_Cloud_Porter();
 		$result = $porter->import_pbp( $pbp, $destination );
 		if ( is_wp_error( $result ) ) {
@@ -303,7 +318,24 @@ class Pattern_Builder_Cloud_Controller {
 		// Remember the linkage so re-uploads offer "update".
 		Pattern_Builder_Cloud::set_link( Pattern_Builder_Cloud_Porter::local_key( $result['type'], $result['id'] ), $cloud_id );
 
+		$result['tokensWritten'] = $tokens_written;
 		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * POST /cloud/tokens/check — which of a pattern's tokens this site
+	 * lacks, so the download flow knows whether to ask where to put them.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return WP_REST_Response
+	 */
+	public function tokens_check( $request ) {
+		$tokens = $request->get_param( 'tokens' );
+		return rest_ensure_response(
+			array(
+				'missing' => Pattern_Builder_Cloud_Tokens::missing( is_array( $tokens ) ? $tokens : array() ),
+			)
+		);
 	}
 
 	/**

--- a/includes/class-pattern-builder-cloud-porter.php
+++ b/includes/class-pattern-builder-cloud-porter.php
@@ -81,6 +81,7 @@ class Pattern_Builder_Cloud_Porter {
 			'templateTypes' => array_values( (array) $pattern->templateTypes ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			'content'       => $content,
 			'assets'        => array_values( $assets ),
+			'tokens'        => Pattern_Builder_Cloud_Tokens::collect( (string) $pattern->content ),
 			'origin'        => array(
 				'site' => home_url(),
 				'kind' => $type,

--- a/includes/class-pattern-builder-cloud-tokens.php
+++ b/includes/class-pattern-builder-cloud-tokens.php
@@ -1,0 +1,485 @@
+<?php
+
+namespace TwentyBellows\PatternBuilder;
+
+use WP_Error;
+use WP_Theme_JSON_Resolver;
+
+/**
+ * Design tokens: the preset references a pattern carries between sites.
+ *
+ * On upload, collect() scans the pattern's markup for every theme.json
+ * preset it references (colors, gradients, spacing sizes, font sizes, font
+ * families) and resolves each slug against this site's merged global
+ * settings — the pattern travels with the values it actually had here.
+ *
+ * On download, missing() reports which referenced tokens the destination
+ * site doesn't define (the destination's own definitions always win), and
+ * apply() writes those into the chosen home: the theme's user Global
+ * Styles post, or the active theme's theme.json file.
+ */
+class Pattern_Builder_Cloud_Tokens {
+
+	/**
+	 * Token types, with the settings path their presets live under and the
+	 * key holding the value in a preset entry.
+	 *
+	 * @return array type => { path: string[], valueKey: string }
+	 */
+	public static function types() {
+		return array(
+			'color'      => array(
+				'path'      => array( 'color', 'palette' ),
+				'value_key' => 'color',
+			),
+			'gradient'   => array(
+				'path'      => array( 'color', 'gradients' ),
+				'value_key' => 'gradient',
+			),
+			'spacing'    => array(
+				'path'      => array( 'spacing', 'spacingSizes' ),
+				'value_key' => 'size',
+			),
+			'fontSize'   => array(
+				'path'      => array( 'typography', 'fontSizes' ),
+				'value_key' => 'size',
+			),
+			'fontFamily' => array(
+				'path'      => array( 'typography', 'fontFamilies' ),
+				'value_key' => 'fontFamily',
+			),
+		);
+	}
+
+	/**
+	 * Collect the tokens a pattern's markup references, resolved to this
+	 * site's current values. References this site can't resolve are
+	 * dropped (there is no default to carry).
+	 *
+	 * @param string $content Serialized block markup.
+	 * @return array PBP token list.
+	 */
+	public static function collect( $content ) {
+		$tokens = array();
+
+		foreach ( self::referenced( $content ) as $type => $slugs ) {
+			foreach ( $slugs as $slug ) {
+				$preset = self::find_preset( $type, $slug );
+				if ( ! $preset ) {
+					continue;
+				}
+
+				$value = self::preset_value( $type, $preset );
+				if ( '' === $value ) {
+					continue;
+				}
+
+				$tokens[] = array(
+					'type'  => $type,
+					'slug'  => $slug,
+					'name'  => isset( $preset['name'] ) ? (string) $preset['name'] : ucwords( str_replace( '-', ' ', $slug ) ),
+					'value' => $value,
+				);
+			}
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Every preset reference in a pattern's markup, by token type.
+	 *
+	 * Sources: named block attributes, `var:preset|…` style paths,
+	 * `var(--wp--preset--…)` custom properties, and the derived
+	 * `has-…` classes.
+	 *
+	 * @param string $content Serialized block markup.
+	 * @return array type => slug[]
+	 */
+	public static function referenced( $content ) {
+		$found = array();
+		$note  = function ( $type, $slug ) use ( &$found ) {
+			$slug = strtolower( (string) $slug );
+			if ( preg_match( '/^[a-z0-9-]{1,64}$/', $slug ) ) {
+				$found[ $type ][ $slug ] = true;
+			}
+		};
+
+		// Named attributes inside block comment JSON.
+		$attr_types = array(
+			'textColor'       => 'color',
+			'backgroundColor' => 'color',
+			'borderColor'     => 'color',
+			'gradient'        => 'gradient',
+			'fontSize'        => 'fontSize',
+			'fontFamily'      => 'fontFamily',
+		);
+		foreach ( $attr_types as $attr => $type ) {
+			if ( preg_match_all( '/"' . $attr . '"\s*:\s*"([a-z0-9-]+)"/i', $content, $matches ) ) {
+				foreach ( $matches[1] as $slug ) {
+					$note( $type, $slug );
+				}
+			}
+		}
+
+		// Style-object preset paths and rendered custom properties. The
+		// wire spelling of each type is kebab-case.
+		$path_types = array(
+			'color'       => 'color',
+			'gradient'    => 'gradient',
+			'spacing'     => 'spacing',
+			'font-size'   => 'fontSize',
+			'font-family' => 'fontFamily',
+		);
+		if ( preg_match_all( '/var:preset\|([a-z-]+)\|([a-z0-9-]+)/i', $content, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				if ( isset( $path_types[ strtolower( $match[1] ) ] ) ) {
+					$note( $path_types[ strtolower( $match[1] ) ], $match[2] );
+				}
+			}
+		}
+		if ( preg_match_all( '/var\(--wp--preset--([a-z-]+?)--([a-z0-9-]+)\)/i', $content, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				if ( isset( $path_types[ strtolower( $match[1] ) ] ) ) {
+					$note( $path_types[ strtolower( $match[1] ) ], $match[2] );
+				}
+			}
+		}
+
+		/*
+		 * Derived classes. Generic support classes (has-text-color,
+		 * has-link-color, has-border-color, has-background) are not preset
+		 * references — exclude their pseudo-slugs.
+		 */
+		$class_types = array(
+			'/\bhas-([a-z0-9-]+)-color\b/'               => array( 'color', array( 'text', 'link', 'border', 'icon', 'heading', 'caption', 'button' ) ),
+			'/\bhas-([a-z0-9-]+)-background-color\b/'    => array( 'color', array() ),
+			'/\bhas-([a-z0-9-]+)-border-color\b/'        => array( 'color', array() ),
+			'/\bhas-([a-z0-9-]+)-gradient-background\b/' => array( 'gradient', array() ),
+			'/\bhas-([a-z0-9-]+)-font-size\b/'           => array( 'fontSize', array() ),
+			'/\bhas-([a-z0-9-]+)-font-family\b/'         => array( 'fontFamily', array() ),
+		);
+		foreach ( $class_types as $regex => $spec ) {
+			if ( preg_match_all( $regex, $content, $matches ) ) {
+				foreach ( $matches[1] as $slug ) {
+					// The greedy -color match also swallows the longer
+					// -background-color / -border-color classes, which the
+					// specific regexes already captured with the right slug.
+					if ( preg_match( '/-(background|border)$/', $slug ) ) {
+						continue;
+					}
+					if ( ! in_array( $slug, $spec[1], true ) ) {
+						$note( $spec[0], $slug );
+					}
+				}
+			}
+		}
+
+		return array_map( 'array_keys', $found );
+	}
+
+	/**
+	 * The subset of a package's tokens this site does not define.
+	 *
+	 * @param array $tokens PBP token list.
+	 * @return array
+	 */
+	public static function missing( $tokens ) {
+		$missing = array();
+		foreach ( (array) $tokens as $token ) {
+			if ( ! is_array( $token ) || empty( $token['type'] ) || empty( $token['slug'] ) ) {
+				continue;
+			}
+			if ( ! array_key_exists( $token['type'], self::types() ) ) {
+				continue;
+			}
+			if ( ! self::find_preset( $token['type'], $token['slug'] ) ) {
+				$missing[] = $token;
+			}
+		}
+		return $missing;
+	}
+
+	/**
+	 * Write tokens into the chosen home. Tokens the site already defines
+	 * are skipped; values are re-validated locally (never trust the wire).
+	 *
+	 * @param array  $tokens      PBP token list (normally missing() output).
+	 * @param string $destination 'user' (Global Styles) or 'theme' (theme.json).
+	 * @return array|WP_Error Slugs written, keyed by type.
+	 */
+	public static function apply( $tokens, $destination ) {
+		$to_write = array();
+		foreach ( self::missing( $tokens ) as $token ) {
+			$value = self::sanitize_value( $token['type'], isset( $token['value'] ) ? (string) $token['value'] : '' );
+			if ( false === $value ) {
+				return new WP_Error(
+					'pb_cloud_bad_token',
+					sprintf(
+						/* translators: %s: token slug. */
+						__( 'The pattern carries an invalid value for the "%s" token.', 'pattern-builder' ),
+						$token['slug']
+					),
+					array( 'status' => 400 )
+				);
+			}
+			$token['value']               = $value;
+			$to_write[ $token['type'] ][] = $token;
+		}
+
+		if ( ! $to_write ) {
+			return array();
+		}
+
+		$result = 'theme' === $destination
+			? self::write_theme_json( $to_write )
+			: self::write_user_styles( $to_write );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		wp_clean_theme_json_cache();
+
+		$written = array();
+		foreach ( $to_write as $type => $list ) {
+			$written[ $type ] = wp_list_pluck( $list, 'slug' );
+		}
+		return $written;
+	}
+
+	/**
+	 * Merge tokens into the theme's user Global Styles post.
+	 *
+	 * @param array $to_write type => token[].
+	 * @return true|WP_Error
+	 */
+	private static function write_user_styles( $to_write ) {
+		$post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+		if ( ! $post_id ) {
+			return new WP_Error( 'pb_cloud_no_global_styles', __( 'This site has no Global Styles storage for the active theme.', 'pattern-builder' ), array( 'status' => 500 ) );
+		}
+
+		$post   = get_post( $post_id );
+		$config = $post ? json_decode( (string) $post->post_content, true ) : null;
+		if ( ! is_array( $config ) ) {
+			$config = array();
+		}
+		$config['version']                     = isset( $config['version'] ) ? $config['version'] : 3;
+		$config['isGlobalStylesUserThemeJSON'] = true;
+
+		$config = self::merge_settings( $config, $to_write );
+
+		$updated = wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => wp_slash( wp_json_encode( $config ) ),
+			),
+			true
+		);
+
+		return is_wp_error( $updated ) ? $updated : true;
+	}
+
+	/**
+	 * Merge tokens into the active theme's theme.json file.
+	 *
+	 * @param array $to_write type => token[].
+	 * @return true|WP_Error
+	 */
+	private static function write_theme_json( $to_write ) {
+		$path = get_stylesheet_directory() . '/theme.json';
+		if ( ! file_exists( $path ) ) {
+			return new WP_Error( 'pb_cloud_no_theme_json', __( 'The active theme has no theme.json — add these tokens to Site styles instead.', 'pattern-builder' ), array( 'status' => 400 ) );
+		}
+		if ( ! wp_is_writable( $path ) ) {
+			return new WP_Error( 'pb_cloud_theme_json_readonly', __( 'theme.json is not writable — add these tokens to Site styles instead.', 'pattern-builder' ), array( 'status' => 400 ) );
+		}
+
+		$config = json_decode( (string) file_get_contents( $path ), true ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local theme file.
+		if ( ! is_array( $config ) ) {
+			return new WP_Error( 'pb_cloud_theme_json_invalid', __( 'theme.json could not be parsed.', 'pattern-builder' ), array( 'status' => 500 ) );
+		}
+
+		$config = self::merge_settings( $config, $to_write );
+
+		$written = file_put_contents( $path, wp_json_encode( $config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Same direct write path Pattern_File_Store uses for theme files.
+		if ( false === $written ) {
+			return new WP_Error( 'pb_cloud_theme_json_write', __( 'theme.json could not be written.', 'pattern-builder' ), array( 'status' => 500 ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Append token presets under a config's settings paths (skipping slugs
+	 * that already exist at that path).
+	 *
+	 * @param array $config   theme.json-shaped config.
+	 * @param array $to_write type => token[].
+	 * @return array
+	 */
+	private static function merge_settings( $config, $to_write ) {
+		$types = self::types();
+
+		foreach ( $to_write as $type => $list ) {
+			$path      = $types[ $type ]['path'];
+			$value_key = $types[ $type ]['value_key'];
+
+			$existing = isset( $config['settings'][ $path[0] ][ $path[1] ] ) && is_array( $config['settings'][ $path[0] ][ $path[1] ] )
+				? $config['settings'][ $path[0] ][ $path[1] ]
+				: array();
+			$slugs    = array();
+			foreach ( $existing as $entry ) {
+				if ( is_array( $entry ) && isset( $entry['slug'] ) ) {
+					$slugs[ strtolower( (string) $entry['slug'] ) ] = true;
+				}
+			}
+
+			foreach ( $list as $token ) {
+				if ( isset( $slugs[ $token['slug'] ] ) ) {
+					continue;
+				}
+				$existing[] = array(
+					'slug'     => $token['slug'],
+					'name'     => $token['name'],
+					$value_key => $token['value'],
+				);
+			}
+
+			$config['settings'][ $path[0] ][ $path[1] ] = $existing;
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Find a preset by slug in this site's merged settings, preferring
+	 * user customizations over the theme over core defaults.
+	 *
+	 * @param string $type Token type.
+	 * @param string $slug Preset slug.
+	 * @return array|null Preset entry.
+	 */
+	private static function find_preset( $type, $slug ) {
+		$types = self::types();
+		if ( ! isset( $types[ $type ] ) ) {
+			return null;
+		}
+
+		$presets = wp_get_global_settings( $types[ $type ]['path'] );
+		if ( ! is_array( $presets ) ) {
+			return null;
+		}
+
+		// Origin-keyed (default/theme/custom) or, defensively, a flat list.
+		$origins = array();
+		foreach ( array( 'custom', 'theme', 'default' ) as $origin ) {
+			if ( isset( $presets[ $origin ] ) && is_array( $presets[ $origin ] ) ) {
+				$origins[] = $presets[ $origin ];
+			}
+		}
+		if ( ! $origins && array_values( $presets ) === $presets ) {
+			$origins[] = $presets;
+		}
+
+		foreach ( $origins as $list ) {
+			foreach ( $list as $entry ) {
+				if ( is_array( $entry ) && isset( $entry['slug'] ) && strtolower( (string) $entry['slug'] ) === strtolower( (string) $slug ) ) {
+					return $entry;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * The CSS value a preset entry resolves to.
+	 *
+	 * @param string $type   Token type.
+	 * @param array  $preset Preset entry.
+	 * @return string
+	 */
+	private static function preset_value( $type, $preset ) {
+		$value_key = self::types()[ $type ]['value_key'];
+
+		if ( 'fontSize' === $type && function_exists( 'wp_get_typography_font_size_value' ) ) {
+			// Applies fluid typography, matching what the site renders.
+			$value = wp_get_typography_font_size_value( $preset );
+			return is_string( $value ) ? $value : '';
+		}
+
+		return isset( $preset[ $value_key ] ) && is_string( $preset[ $value_key ] ) ? $preset[ $value_key ] : '';
+	}
+
+	/**
+	 * The same strict per-type value grammar the service enforces —
+	 * re-run locally before anything is written (never trust the wire).
+	 *
+	 * @param string $type  Token type.
+	 * @param string $value Raw value.
+	 * @return string|false
+	 */
+	public static function sanitize_value( $type, $value ) {
+		$value = trim( (string) $value );
+		if ( '' === $value || strlen( $value ) > 400 ) {
+			return false;
+		}
+
+		$lower = strtolower( $value );
+		foreach ( array( 'url(', 'expression(', 'var(', 'image-set(', '@', ';', '{', '}', '<', '>', '\\' ) as $forbidden ) {
+			if ( false !== strpos( $lower, $forbidden ) ) {
+				return false;
+			}
+		}
+
+		switch ( $type ) {
+			case 'color':
+				if ( preg_match( '/^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i', $value ) ) {
+					return $lower;
+				}
+				if ( in_array( $lower, array( 'transparent', 'currentcolor' ), true ) ) {
+					return $lower;
+				}
+				if ( preg_match( '/^(rgba?|hsla?)\(\s*[0-9\.\,\s%\/deg]+\)$/i', $value ) ) {
+					return preg_replace( '/\s+/', ' ', $lower );
+				}
+				return false;
+
+			case 'gradient':
+				if ( ! preg_match( '/^(linear|radial|conic)-gradient\(/i', $value ) ) {
+					return false;
+				}
+				if ( ! preg_match( '/^[a-z0-9#\s\.\,\%\(\)\/\-\+\*]+$/i', $value ) ) {
+					return false;
+				}
+				if ( substr_count( $value, '(' ) !== substr_count( $value, ')' ) ) {
+					return false;
+				}
+				return $value;
+
+			case 'spacing':
+			case 'fontSize':
+				if ( ! preg_match( '/^[a-z0-9\s\.\,\%\(\)\/\-\+\*]+$/i', $value ) ) {
+					return false;
+				}
+				if ( substr_count( $value, '(' ) !== substr_count( $value, ')' ) ) {
+					return false;
+				}
+				$residue = preg_replace( '/\b(clamp|calc|min|max)\(/i', '(', $value );
+				$residue = preg_replace( '/(?<=[0-9\s])(px|rem|em|%|vw|vh|svw|svh|dvw|dvh|ch|ex|pt)\b/i', '', $residue );
+				if ( preg_match( '/[a-z]/i', $residue ) ) {
+					return false;
+				}
+				return $value;
+
+			case 'fontFamily':
+				if ( ! preg_match( '/^[a-z0-9\s\,\'\"\-]+$/i', $value ) ) {
+					return false;
+				}
+				return $value;
+		}
+
+		return false;
+	}
+}

--- a/includes/class-pattern-builder.php
+++ b/includes/class-pattern-builder.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/class-pattern-builder-admin.php';
 require_once __DIR__ . '/class-pattern-builder-editor.php';
 require_once __DIR__ . '/class-pattern-builder-migration.php';
 require_once __DIR__ . '/class-pattern-builder-cloud.php';
+require_once __DIR__ . '/class-pattern-builder-cloud-tokens.php';
 require_once __DIR__ . '/class-pattern-builder-cloud-porter.php';
 require_once __DIR__ . '/class-pattern-builder-cloud-controller.php';
 

--- a/src/cloud/CloudBrowser.js
+++ b/src/cloud/CloudBrowser.js
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import {
 	Button,
@@ -189,6 +189,112 @@ function CloudDetails( { pattern, source, onDownload, onDelete, busy } ) {
 				</Button>
 			) }
 		</VStack>
+	);
+}
+
+/**
+ * The missing-tokens step of a download: the pattern references design
+ * tokens this site doesn't define, so ask where to put them (the
+ * destination's own definitions always win and are never listed here).
+ *
+ * @param {Object}   props           Component props.
+ * @param {Array}    props.missing   Tokens the site lacks.
+ * @param {boolean}  props.busy      Whether the download is in flight.
+ * @param {Function} props.onConfirm Called with 'user' or 'theme'.
+ * @param {Function} props.onClose   Close/cancel callback.
+ */
+function TokensModal( { missing, busy, onConfirm, onClose } ) {
+	const [ destination, setDestination ] = useState( 'user' );
+
+	const typeLabels = {
+		color: __( 'Color', 'pattern-builder' ),
+		gradient: __( 'Gradient', 'pattern-builder' ),
+		spacing: __( 'Spacing', 'pattern-builder' ),
+		fontSize: __( 'Font size', 'pattern-builder' ),
+		fontFamily: __( 'Font family', 'pattern-builder' ),
+	};
+
+	return (
+		<Modal
+			title={ __(
+				'This pattern brings new design tokens',
+				'pattern-builder'
+			) }
+			onRequestClose={ onClose }
+			className="pattern-builder-cloud__tokens-modal"
+		>
+			<p className="pattern-builder-cloud__meta">
+				{ __(
+					'The pattern references design tokens this site doesn’t define yet. They’ll be added with the values from the pattern’s source site; tokens your site already defines keep your values.',
+					'pattern-builder'
+				) }
+			</p>
+			<ul className="pattern-builder-cloud__tokens-list">
+				{ missing.map( ( token ) => (
+					<li key={ `${ token.type }:${ token.slug }` }>
+						{ ( token.type === 'color' ||
+							token.type === 'gradient' ) && (
+							<span
+								className="pattern-builder-cloud__token-swatch"
+								style={ { background: token.value } }
+							/>
+						) }
+						<span className="pattern-builder-cloud__token-name">
+							{ token.name || token.slug }
+						</span>
+						<span className="pattern-builder-cloud__token-meta">
+							{ typeLabels[ token.type ] || token.type }
+						</span>
+						<code className="pattern-builder-cloud__token-value">
+							{ token.value }
+						</code>
+					</li>
+				) ) }
+			</ul>
+			<SelectControl
+				__nextHasNoMarginBottom
+				label={ __( 'Add them to', 'pattern-builder' ) }
+				value={ destination }
+				options={ [
+					{
+						label: __(
+							'Site styles (Global Styles) — recommended, revertable in the editor',
+							'pattern-builder'
+						),
+						value: 'user',
+					},
+					{
+						label: __(
+							'The active theme’s theme.json file — ships with the theme',
+							'pattern-builder'
+						),
+						value: 'theme',
+					},
+				] }
+				onChange={ setDestination }
+			/>
+			<HStack
+				alignment="right"
+				spacing={ 2 }
+				className="pattern-builder-cloud__tokens-actions"
+			>
+				<Button
+					variant="tertiary"
+					onClick={ onClose }
+					disabled={ busy }
+				>
+					{ __( 'Cancel', 'pattern-builder' ) }
+				</Button>
+				<Button
+					variant="primary"
+					isBusy={ busy }
+					disabled={ busy }
+					onClick={ () => onConfirm( destination ) }
+				>
+					{ __( 'Add tokens & download', 'pattern-builder' ) }
+				</Button>
+			</HStack>
+		</Modal>
 	);
 }
 
@@ -585,6 +691,7 @@ export function CloudBrowser( { view, onDownloaded } ) {
 	const [ isUploadOpen, setIsUploadOpen ] = useState( false );
 	const [ links, setLinks ] = useState( {} );
 	const [ uploadBusyKey, setUploadBusyKey ] = useState( '' );
+	const [ pendingDownload, setPendingDownload ] = useState( null );
 
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
@@ -735,7 +842,35 @@ export function CloudBrowser( { view, onDownloaded } ) {
 		);
 	};
 
+	// Gate the download on the pattern's design tokens: when it references
+	// tokens this site lacks, ask where to define them first (§4a).
 	const download = ( pattern, destination ) => {
+		if ( ! pattern.tokens?.length ) {
+			performDownload( pattern, destination );
+			return;
+		}
+		setBusy( true );
+		apiFetch( {
+			path: `${ BASE }/tokens/check`,
+			method: 'POST',
+			data: { tokens: pattern.tokens },
+		} )
+			.then( ( check ) => {
+				if ( check.missing?.length ) {
+					setBusy( false );
+					setPendingDownload( {
+						pattern,
+						destination,
+						missing: check.missing,
+					} );
+				} else {
+					performDownload( pattern, destination );
+				}
+			} )
+			.catch( () => performDownload( pattern, destination ) );
+	};
+
+	const performDownload = ( pattern, destination, tokenDestination ) => {
 		setBusy( true );
 		apiFetch( {
 			path: `${ BASE }/download`,
@@ -744,9 +879,11 @@ export function CloudBrowser( { view, onDownloaded } ) {
 				source: view === CLOUD_DIRECTORY ? 'directory' : 'library',
 				cloudId: pattern.id,
 				destination,
+				tokenDestination,
 			},
 		} )
 			.then( ( result ) => {
+				setPendingDownload( null );
 				const message =
 					destination === 'theme'
 						? sprintf(
@@ -766,6 +903,27 @@ export function CloudBrowser( { view, onDownloaded } ) {
 								result.title
 						  );
 				createSuccessNotice( message, { type: 'snackbar' } );
+				const writtenCount = Object.values(
+					result.tokensWritten || {}
+				).reduce( ( sum, slugs ) => sum + slugs.length, 0 );
+				if ( writtenCount > 0 ) {
+					createSuccessNotice(
+						sprintf(
+							/* translators: 1: token count, 2: where they were added. */
+							_n(
+								'%1$d design token added to %2$s.',
+								'%1$d design tokens added to %2$s.',
+								writtenCount,
+								'pattern-builder'
+							),
+							writtenCount,
+							tokenDestination === 'theme'
+								? __( 'theme.json', 'pattern-builder' )
+								: __( 'Site styles', 'pattern-builder' )
+						),
+						{ type: 'snackbar' }
+					);
+				}
 				onDownloaded?.();
 			} )
 			.catch( ( error ) => {
@@ -922,6 +1080,21 @@ export function CloudBrowser( { view, onDownloaded } ) {
 		);
 	}
 
+	const tokensModal = pendingDownload && (
+		<TokensModal
+			missing={ pendingDownload.missing }
+			busy={ busy }
+			onConfirm={ ( tokenDestination ) =>
+				performDownload(
+					pendingDownload.pattern,
+					pendingDownload.destination,
+					tokenDestination
+				)
+			}
+			onClose={ () => setPendingDownload( null ) }
+		/>
+	);
+
 	if ( isGenerate ) {
 		return (
 			<div className="pattern-builder-cloud">
@@ -932,6 +1105,7 @@ export function CloudBrowser( { view, onDownloaded } ) {
 					onDelete={ deleteCloudPattern }
 					onCreditsChanged={ refreshStatus }
 				/>
+				{ tokensModal }
 			</div>
 		);
 	}
@@ -1126,6 +1300,8 @@ export function CloudBrowser( { view, onDownloaded } ) {
 					onClose={ () => setIsUploadOpen( false ) }
 				/>
 			) }
+
+			{ tokensModal }
 		</div>
 	);
 }

--- a/src/cloud/cloud.scss
+++ b/src/cloud/cloud.scss
@@ -172,3 +172,51 @@
 	color: #b32d2e;
 	font-size: 13px;
 }
+
+.pattern-builder-cloud__tokens-modal {
+	max-width: 520px;
+}
+
+.pattern-builder-cloud__tokens-list {
+	margin: 12px 0 16px;
+	padding: 0;
+	list-style: none;
+
+	li {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 7px 0;
+		border-bottom: 1px solid #f0f0f1;
+		font-size: 13px;
+	}
+}
+
+.pattern-builder-cloud__token-swatch {
+	flex: none;
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	border: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.pattern-builder-cloud__token-name {
+	font-weight: 500;
+}
+
+.pattern-builder-cloud__token-meta {
+	color: #50575e;
+}
+
+.pattern-builder-cloud__token-value {
+	margin-left: auto;
+	max-width: 45%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 11px;
+}
+
+.pattern-builder-cloud__tokens-actions {
+	margin-top: 16px;
+}

--- a/tests/php/test-cloud-tokens.php
+++ b/tests/php/test-cloud-tokens.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Design tokens: reference scanning, resolution against global settings,
+ * missing-token detection, and the Global Styles / theme.json writers.
+ *
+ * @package PatternBuilder
+ */
+
+use TwentyBellows\PatternBuilder\Pattern_Builder_Cloud_Tokens;
+
+class Test_Cloud_Tokens extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		add_filter( 'wp_theme_json_data_theme', array( $this, 'inject_theme_presets' ) );
+		wp_clean_theme_json_cache();
+	}
+
+	public function tear_down() {
+		remove_filter( 'wp_theme_json_data_theme', array( $this, 'inject_theme_presets' ) );
+		wp_clean_theme_json_cache();
+		$theme_json = get_stylesheet_directory() . '/theme.json';
+		if ( file_exists( $theme_json ) ) {
+			unlink( $theme_json );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Give the test theme a known palette/spacing/typography.
+	 *
+	 * @param WP_Theme_JSON_Data $theme_json Theme data.
+	 * @return WP_Theme_JSON_Data
+	 */
+	public function inject_theme_presets( $theme_json ) {
+		return $theme_json->update_with(
+			array(
+				'version'  => 3,
+				'settings' => array(
+					'color'      => array(
+						'palette'   => array(
+							array(
+								'slug'  => 'brand',
+								'name'  => 'Brand',
+								'color' => '#4f46e5',
+							),
+						),
+						'gradients' => array(
+							array(
+								'slug'     => 'dusk',
+								'name'     => 'Dusk',
+								'gradient' => 'linear-gradient(135deg, #4f46e5 0%, #14141f 100%)',
+							),
+						),
+					),
+					'spacing'    => array(
+						'spacingSizes' => array(
+							array(
+								'slug' => 'jumbo',
+								'name' => 'Jumbo',
+								'size' => '5rem',
+							),
+						),
+					),
+					'typography' => array(
+						'fontSizes'    => array(
+							array(
+								'slug' => 'mega',
+								'name' => 'Mega',
+								'size' => '3.5rem',
+							),
+						),
+						'fontFamilies' => array(
+							array(
+								'slug'       => 'body-face',
+								'name'       => 'Body Face',
+								'fontFamily' => "Inter, 'Segoe UI', sans-serif",
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	private function sample_markup() {
+		return '<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|jumbo"}}},"backgroundColor":"brand","fontFamily":"body-face"} -->
+<div class="wp-block-group has-brand-background-color has-background has-body-face-font-family" style="padding-top:var(--wp--preset--spacing--jumbo)"><!-- wp:heading {"fontSize":"mega","gradient":"dusk"} -->
+<h2 class="wp-block-heading has-dusk-gradient-background has-mega-font-size">Hello</h2>
+<!-- /wp:heading --><!-- wp:paragraph {"textColor":"brand"} -->
+<p class="has-brand-color has-text-color">Copy</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->';
+	}
+
+	public function test_referenced_finds_every_reference_form_and_skips_support_classes() {
+		$refs = Pattern_Builder_Cloud_Tokens::referenced( $this->sample_markup() );
+
+		$this->assertSame( array( 'brand' ), $refs['color'] );
+		$this->assertSame( array( 'body-face' ), $refs['fontFamily'] );
+		$this->assertSame( array( 'jumbo' ), $refs['spacing'] );
+		$this->assertSame( array( 'mega' ), $refs['fontSize'] );
+		$this->assertSame( array( 'dusk' ), $refs['gradient'] );
+	}
+
+	public function test_collect_resolves_against_merged_settings() {
+		$tokens = Pattern_Builder_Cloud_Tokens::collect( $this->sample_markup() );
+
+		$by_key = array();
+		foreach ( $tokens as $token ) {
+			$by_key[ $token['type'] . ':' . $token['slug'] ] = $token;
+		}
+
+		$this->assertSame( '#4f46e5', $by_key['color:brand']['value'] );
+		$this->assertSame( 'Brand', $by_key['color:brand']['name'] );
+		$this->assertSame( '5rem', $by_key['spacing:jumbo']['value'] );
+		$this->assertSame( '3.5rem', $by_key['fontSize:mega']['value'] );
+		$this->assertSame( "Inter, 'Segoe UI', sans-serif", $by_key['fontFamily:body-face']['value'] );
+		$this->assertStringStartsWith( 'linear-gradient', $by_key['gradient:dusk']['value'] );
+	}
+
+	public function test_collect_drops_unresolvable_references() {
+		$tokens = Pattern_Builder_Cloud_Tokens::collect( '<!-- wp:paragraph {"textColor":"no-such-slug"} --><p class="has-no-such-slug-color has-text-color">x</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame( array(), $tokens );
+	}
+
+	public function test_missing_respects_existing_definitions_from_any_origin() {
+		$tokens = array(
+			array(
+				'type'  => 'color',
+				'slug'  => 'brand',
+				'name'  => 'Brand',
+				'value' => '#123456',
+			), // Theme-defined here — not missing, local value wins.
+			array(
+				'type'  => 'color',
+				'slug'  => 'imported-accent',
+				'name'  => 'Imported Accent',
+				'value' => '#aa5500',
+			),
+		);
+
+		$missing = Pattern_Builder_Cloud_Tokens::missing( $tokens );
+
+		$this->assertCount( 1, $missing );
+		$this->assertSame( 'imported-accent', $missing[0]['slug'] );
+	}
+
+	public function test_apply_writes_to_user_global_styles_idempotently() {
+		$token = array(
+			'type'  => 'color',
+			'slug'  => 'imported-accent',
+			'name'  => 'Imported Accent',
+			'value' => '#aa5500',
+		);
+
+		$written = Pattern_Builder_Cloud_Tokens::apply( array( $token ), 'user' );
+		$this->assertSame( array( 'color' => array( 'imported-accent' ) ), $written );
+
+		// Now resolvable — and a second apply writes nothing.
+		$this->assertSame( array(), Pattern_Builder_Cloud_Tokens::missing( array( $token ) ) );
+		$this->assertSame( array(), Pattern_Builder_Cloud_Tokens::apply( array( $token ), 'user' ) );
+
+		// The value round-trips through the global styles pipeline.
+		$collected = Pattern_Builder_Cloud_Tokens::collect( '<!-- wp:paragraph {"textColor":"imported-accent"} --><p>x</p><!-- /wp:paragraph -->' );
+		$this->assertSame( '#aa5500', $collected[0]['value'] );
+	}
+
+	public function test_apply_writes_to_theme_json() {
+		$path = get_stylesheet_directory() . '/theme.json';
+		file_put_contents( $path, wp_json_encode( array( 'version' => 3 ) ) );
+		wp_clean_theme_json_cache();
+
+		$written = Pattern_Builder_Cloud_Tokens::apply(
+			array(
+				array(
+					'type'  => 'spacing',
+					'slug'  => 'imported-gap',
+					'name'  => 'Imported Gap',
+					'value' => '2.5rem',
+				),
+			),
+			'theme'
+		);
+
+		$this->assertSame( array( 'spacing' => array( 'imported-gap' ) ), $written );
+
+		$config = json_decode( file_get_contents( $path ), true );
+		$this->assertSame( 'imported-gap', $config['settings']['spacing']['spacingSizes'][0]['slug'] );
+		$this->assertSame( '2.5rem', $config['settings']['spacing']['spacingSizes'][0]['size'] );
+	}
+
+	public function test_apply_theme_requires_theme_json() {
+		$result = Pattern_Builder_Cloud_Tokens::apply(
+			array(
+				array(
+					'type'  => 'color',
+					'slug'  => 'imported-accent',
+					'name'  => 'Imported Accent',
+					'value' => '#aa5500',
+				),
+			),
+			'theme'
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'pb_cloud_no_theme_json', $result->get_error_code() );
+	}
+
+	public function test_apply_rejects_hostile_wire_values() {
+		$result = Pattern_Builder_Cloud_Tokens::apply(
+			array(
+				array(
+					'type'  => 'color',
+					'slug'  => 'evil',
+					'name'  => 'Evil',
+					'value' => 'red; background:url(javascript:alert(1))',
+				),
+			),
+			'user'
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'pb_cloud_bad_token', $result->get_error_code() );
+	}
+
+	public function test_porter_export_bundles_tokens() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Tokened Pattern',
+				'post_name'    => 'tokened-pattern',
+				'post_content' => $this->sample_markup(),
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+			)
+		);
+		update_post_meta( $post_id, 'wp_pattern_sync_status', 'unsynced' );
+
+		$porter   = new TwentyBellows\PatternBuilder\Pattern_Builder_Cloud_Porter();
+		$exported = $porter->export_local( 'user', $post_id );
+
+		$this->assertIsArray( $exported );
+		$slugs = wp_list_pluck( $exported['pbp']['tokens'], 'slug' );
+		$this->assertContains( 'brand', $slugs );
+		$this->assertContains( 'jumbo', $slugs );
+		$this->assertContains( 'mega', $slugs );
+	}
+}


### PR DESCRIPTION
Stacked on #47 (its diff shows only token work; it retargets when #47 merges). Server half: [Twenty-Bellows/patternbuilderwp.com#4](https://github.com/Twenty-Bellows/patternbuilderwp.com/pull/4).

Patterns reference theme presets by slug — a foreground color, a spacing step, a font size. This PR makes those references portable per the agreed semantics: **the uploading site's values travel as defaults; the downloading site's own definitions always win; only missing tokens prompt the user for a home.**

## Upload — automatic

`Pattern_Builder_Cloud_Tokens::collect()` scans the serialized markup for every preset reference (named attributes, `var:preset|…` style paths, `var(--wp--preset--…)` custom properties, and derived `has-…` classes — generic support classes like `has-text-color` excluded) and resolves each slug against this site's **merged** global settings (user customizations > theme.json > core defaults), fluid font sizes included via `wp_get_typography_font_size_value()`. The porter bundles the result into the package; nothing to ask.

## Download — destination wins; missing tokens ask once

Before a download runs, the flow checks the pattern's tokens against this site (`POST /cloud/tokens/check`). Tokens the site already defines — any origin — are never touched: the pattern simply adopts the local look. Missing ones open a modal listing them (swatches for colors, values shown) with one batch choice of home:

- **Site styles** (the theme's user Global Styles post) — recommended default, revertable in the editor, and
- **theme.json** (the active theme's file) — versioned, ships with the theme (with graceful errors when the theme has none or it isn't writable).

Values are re-validated locally with the same strict grammar the service enforces before anything is written (never trust the wire), the theme-JSON cache is busted, then the pattern imports as usual; the response reports `tokensWritten` and the UI confirms with a snackbar. Generated-pattern downloads go through the identical gate.

## Verified live (two-site loop)

A Twenty Twenty-Five pattern using `accent-2`, `accent-4`, `spacing|50`, and `x-large` uploaded with all four tokens resolved (including TT25's fluid `clamp()` font size); the service stored them and its preview renders with the source palette. Downloaded onto Twenty Twenty-Three: the modal offered **exactly the two accent colors TT23 lacks** — its own spacing/font-size definitions won silently — wrote them to the user palette on confirm, and the pattern imported rendering correctly.

## Testing

9 new PHPUnit tests (112 total, all green): every reference form extracted with support-classes excluded, resolution against injected theme data, unresolvable references dropped, missing-detection honoring existing origins, idempotent Global Styles writes that round-trip through `wp_get_global_settings()`, theme.json writes + its two error paths, hostile wire values rejected, and porter export bundling. ESLint/PHPCS clean; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jnurSGDDL9SPMcptRgB8U

---
_Generated by [Claude Code](https://claude.ai/code/session_014jnurSGDDL9SPMcptRgB8U)_