### PR TITLE
Keep a synced reference a reference when composing for the editor

### DIFF
--- a/includes/class-editor-support.php
+++ b/includes/class-editor-support.php
@@ -17,8 +17,10 @@ use WP_REST_Response;
  *
  * Since WordPress 6.6 core flattens `core/pattern` blocks server side so the
  * editor doesn't have to (`resolve_pattern_blocks()`), and flattening throws
- * away everything but the pattern's slug. These two hooks compose the patterns
- * first, so what core flattens already has its content in place.
+ * away everything but the pattern's slug — the content, and whether the
+ * reference was to a synced pattern at all. The pattern list is recomposed
+ * from the registry after core has flattened it; templates are composed
+ * before the editor sees them, with anything plain left for the editor.
  *
  * Both are cheap on sites that don't use the feature: the markup is only parsed
  * when a substring check says it might be worth it.
@@ -63,7 +65,11 @@ class Editor_Support {
 	 * Composes the patterns the editor lists, previews and inserts.
 	 *
 	 * Core has already flattened the response by the time this runs, so the
-	 * content is recomposed from the pattern registry rather than patched.
+	 * content is recomposed from the pattern registry rather than patched:
+	 * content written in, plain references inlined as core inlines them, and
+	 * references to synced patterns kept as written — with their content —
+	 * for the editor to render as instances. Core's own resolver is never
+	 * run over the result, since it would flatten those too.
 	 *
 	 * A synced pattern also gains a companion entry here. The inserter hands
 	 * over a pattern's blocks, so a pattern cannot offer a reference to itself;
@@ -103,11 +109,9 @@ class Editor_Support {
 
 			$registered = $registry->get_registered( $pattern['name'] );
 			$markup     = $registered['content'] ?? '';
-			$resolved   = Pattern_Resolver::resolve( $markup );
 
-			if ( $resolved !== $markup ) {
-				// Let core finish the job for any plain pattern blocks left over.
-				$patterns[ $index ]['content'] = serialize_blocks( resolve_pattern_blocks( parse_blocks( $resolved ) ) );
+			if ( Pattern_Resolver::contains_pattern_block( $markup ) ) {
+				$patterns[ $index ]['content'] = Pattern_Resolver::compose( $markup );
 
 				$changed = true;
 			}

--- a/includes/class-pattern-resolver.php
+++ b/includes/class-pattern-resolver.php
@@ -24,6 +24,14 @@ use WP_Block_Patterns_Registry;
  * result is ordinary editable content: values written into the markup, and the
  * `core/pattern-overrides` bindings that asked for them removed. Whatever this
  * leaves behind is a plain pattern block that core resolves as it always has.
+ *
+ * A reference to a *synced* pattern is the one thing never composed. It is a
+ * reference by definition — the editor renders it as an instance, design
+ * locked and slots editable, and the front end renders it from the file — so
+ * writing its content in would hand the editor a copy with the design
+ * unlocked and the link gone. It is kept exactly as written, content and all,
+ * and `compose()` exists so the editor's pattern list can inline everything
+ * else the way core does without core's resolver flattening these too.
  */
 class Pattern_Resolver {
 
@@ -46,6 +54,14 @@ class Pattern_Resolver {
 	 * @var array<string, true>
 	 */
 	private static $expanding = array();
+
+	/**
+	 * Whether plain pattern blocks — no content, none inside — are inlined
+	 * too, the way core's own resolver inlines them. Set by `compose()`.
+	 *
+	 * @var bool
+	 */
+	private static $inline_plain = false;
 
 	/**
 	 * Cheap test for markup that might contain a pattern block.
@@ -77,6 +93,37 @@ class Pattern_Resolver {
 		$blocks     = self::resolve_blocks( parse_blocks( $markup ) );
 
 		return self::$expansions === $expansions ? $markup : serialize_blocks( $blocks );
+	}
+
+	/**
+	 * Composes a pattern the way the editor's pattern list needs it.
+	 *
+	 * Core flattens every `core/pattern` block in that list server side
+	 * (`resolve_pattern_blocks()`), which loses the content attribute and
+	 * turns a synced reference into a copy. This does core's job instead:
+	 * content is written in, plain references are inlined the way core
+	 * inlines them, and synced references are left as written for the
+	 * editor to render as instances.
+	 *
+	 * @param string $markup Block markup.
+	 * @return string Block markup with every pattern block composed into it,
+	 *                except the synced references, or the markup untouched if
+	 *                there were none.
+	 */
+	public static function compose( string $markup ): string {
+		if ( ! self::contains_pattern_block( $markup ) ) {
+			return $markup;
+		}
+
+		self::$inline_plain = true;
+
+		try {
+			$blocks = self::resolve_blocks( parse_blocks( $markup ) );
+		} finally {
+			self::$inline_plain = false;
+		}
+
+		return serialize_blocks( $blocks );
 	}
 
 	/**
@@ -162,7 +209,11 @@ class Pattern_Resolver {
 	 * A pattern block with no content of its own is still expanded when the
 	 * pattern it points at reaches one that has some — otherwise core would
 	 * flatten its way down to that pattern and drop the content. A pattern
-	 * block that leads nowhere near any content is left for core.
+	 * block that leads nowhere near any content is left for core, unless
+	 * `compose()` asked for it to be inlined here instead.
+	 *
+	 * A reference to a synced pattern is never expanded: it is returned as
+	 * written, content and all, so the editor renders it as an instance.
 	 *
 	 * @param array $block A parsed `core/pattern` block.
 	 * @return array[]|null The blocks that replace it, an empty array to drop
@@ -177,6 +228,15 @@ class Pattern_Resolver {
 			return null;
 		}
 
+		/*
+		 * Kept, not left to core: null would hand it to `resolve_pattern_blocks()`,
+		 * which inlines it and drops the content, and that is exactly the copy
+		 * a synced pattern must never become.
+		 */
+		if ( Synced_Patterns::is_synced( $slug ) ) {
+			return array( $block );
+		}
+
 		// A pattern that contains itself is dropped, the way core drops it.
 		if ( isset( self::$expanding[ $slug ] ) ) {
 			return array();
@@ -185,7 +245,7 @@ class Pattern_Resolver {
 		$pattern     = $registry->get_registered( $slug );
 		$has_content = is_array( $content ) && ! empty( $content );
 
-		if ( ! $has_content && ! self::contains_pattern_block( $pattern['content'] ?? null ) ) {
+		if ( ! self::$inline_plain && ! $has_content && ! self::contains_pattern_block( $pattern['content'] ?? null ) ) {
 			return null;
 		}
 
@@ -202,7 +262,7 @@ class Pattern_Resolver {
 		unset( self::$expanding[ $slug ] );
 
 		// Nothing inside needed this resolver, so core should expand it instead.
-		if ( ! $has_content && self::$expansions === $expansions ) {
+		if ( ! self::$inline_plain && ! $has_content && self::$expansions === $expansions ) {
 			return null;
 		}
 

--- a/tests/php/class-pattern-test-case.php
+++ b/tests/php/class-pattern-test-case.php
@@ -83,6 +83,26 @@ abstract class Pattern_Test_Case extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Marks a pattern as synced for the duration of a test, through the
+	 * filter, as a plugin would.
+	 *
+	 * @param string $slug Pattern slug.
+	 * @return void
+	 */
+	protected function mark_synced( string $slug ): void {
+		add_filter(
+			'pattern_builder_synced_patterns',
+			static function ( $slugs ) use ( $slug ) {
+				$slugs[] = $slug;
+
+				return $slugs;
+			}
+		);
+
+		\TwentyBellows\PatternBuilder\Synced_Patterns::flush();
+	}
+
+	/**
 	 * Serializes a `core/pattern` block that carries content.
 	 *
 	 * @param string $slug    Pattern slug.

--- a/tests/php/test-runtime-editor-support.php
+++ b/tests/php/test-runtime-editor-support.php
@@ -72,6 +72,84 @@ class Test_Editor_Support extends Pattern_Test_Case {
 	}
 
 	/**
+	 * A reference to a synced pattern survives the list, content and all.
+	 *
+	 * Core's resolver would inline it — the design unlocked, the link gone —
+	 * so the editor could never show a page pattern's synced sections as the
+	 * instances they are. The reference stays; the editor renders it.
+	 */
+	public function test_patterns_endpoint_keeps_synced_references() {
+		$hero = $this->register_pattern( 'test/hero', $this->bound_heading() );
+		$this->mark_synced( $hero );
+
+		$page = $this->register_pattern(
+			'test/page',
+			'<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group">'
+			. $this->pattern_block( $hero, array( 'headline' => array( 'content' => 'From the page pattern' ) ) )
+			. '</div><!-- /wp:group -->'
+		);
+
+		$pattern = $this->find_pattern( $this->request_patterns(), $page );
+
+		$this->assertNotNull( $pattern );
+
+		$blocks = parse_blocks( $pattern['content'] );
+		$this->assertSame( 'core/group', $blocks[0]['blockName'] );
+
+		$reference = $blocks[0]['innerBlocks'][0];
+		$this->assertSame( 'core/pattern', $reference['blockName'], 'The synced pattern should still be a reference.' );
+		$this->assertSame( $hero, $reference['attrs']['slug'] );
+		$this->assertSame(
+			array( 'headline' => array( 'content' => 'From the page pattern' ) ),
+			$reference['attrs']['content'],
+			'The reference should keep the content the page gave it.'
+		);
+		$this->assertStringNotContainsString( 'Default headline', $pattern['content'] );
+	}
+
+	/**
+	 * Plain references beside a synced one are still inlined, as core would.
+	 */
+	public function test_patterns_endpoint_inlines_plain_references_beside_synced_ones() {
+		$hero = $this->register_pattern( 'test/hero', $this->bound_heading() );
+		$this->mark_synced( $hero );
+
+		$plain = $this->register_pattern(
+			'test/plain',
+			'<!-- wp:paragraph --><p>Inlined by the plugin</p><!-- /wp:paragraph -->'
+		);
+		$page  = $this->register_pattern( 'test/page', $this->pattern_block( $plain ) . $this->pattern_block( $hero ) );
+
+		$pattern = $this->find_pattern( $this->request_patterns(), $page );
+
+		$this->assertNotNull( $pattern );
+
+		$names = array_column( parse_blocks( $pattern['content'] ), 'blockName' );
+		$this->assertContains( 'core/paragraph', $names, 'The plain pattern should be inlined.' );
+		$this->assertContains( 'core/pattern', $names, 'The synced pattern should stay a reference.' );
+		$this->assertSame( 1, substr_count( $pattern['content'], 'wp:pattern ' ) );
+	}
+
+	/**
+	 * A template keeps its synced references for the editor as well.
+	 */
+	public function test_template_keeps_synced_references_for_the_editor() {
+		$hero = $this->register_pattern( 'test/hero', $this->bound_heading() );
+		$this->mark_synced( $hero );
+
+		$template          = new WP_Block_Template();
+		$template->content = $this->pattern_block( $hero, array( 'headline' => array( 'content' => 'From the template' ) ) );
+
+		add_filter( 'pattern_builder_is_editor_request', '__return_true' );
+		$filtered = apply_filters( 'get_block_template', $template, 'test//index', 'wp_template' );
+		remove_filter( 'pattern_builder_is_editor_request', '__return_true' );
+
+		$this->assertStringContainsString( 'wp:pattern', $filtered->content );
+		$this->assertStringContainsString( 'From the template', $filtered->content );
+		$this->assertStringNotContainsString( 'Default headline', $filtered->content );
+	}
+
+	/**
 	 * Patterns that use no content are left exactly as core prepares them.
 	 */
 	public function test_patterns_endpoint_leaves_other_patterns_alone() {
@@ -136,25 +214,6 @@ class Test_Editor_Support extends Pattern_Test_Case {
 		remove_filter( 'pattern_builder_is_editor_request', '__return_true' );
 
 		$this->assertStringContainsString( 'In a list', $filtered[0]->content );
-	}
-
-	/**
-	 * Marks a pattern as synced for the duration of a test.
-	 *
-	 * @param string $slug Pattern slug.
-	 * @return void
-	 */
-	private function mark_synced( string $slug ): void {
-		add_filter(
-			'pattern_builder_synced_patterns',
-			static function ( $slugs ) use ( $slug ) {
-				$slugs[] = $slug;
-
-				return $slugs;
-			}
-		);
-
-		Synced_Patterns::flush();
 	}
 
 	/**

--- a/tests/php/test-runtime-pattern-resolver.php
+++ b/tests/php/test-runtime-pattern-resolver.php
@@ -216,6 +216,82 @@ class Test_Pattern_Resolver extends Pattern_Test_Case {
 	}
 
 	/**
+	 * A reference to a synced pattern is kept as written, content included.
+	 */
+	public function test_synced_reference_is_kept() {
+		$hero = $this->register_pattern( 'test/hero', $this->bound_heading() );
+		$this->mark_synced( $hero );
+
+		$markup = $this->pattern_block( $hero, array( 'headline' => array( 'content' => 'Stays a reference' ) ) );
+
+		$this->assertSame( $markup, Pattern_Resolver::resolve( $markup ) );
+	}
+
+	/**
+	 * A synced reference reached through an unsynced pattern is kept too,
+	 * while the pattern around it is composed.
+	 */
+	public function test_synced_reference_inside_a_composed_pattern_is_kept() {
+		$hero = $this->register_pattern( 'test/hero', $this->bound_heading() );
+		$this->mark_synced( $hero );
+
+		$page = $this->register_pattern(
+			'test/page',
+			$this->bound_heading( 'Page title' )
+			. $this->pattern_block( $hero, array( 'headline' => array( 'content' => 'Section' ) ) )
+		);
+
+		$resolved = Pattern_Resolver::resolve(
+			$this->pattern_block( $page, array( 'headline' => array( 'content' => 'Composed title' ) ) )
+		);
+
+		$blocks = array_values( array_filter( parse_blocks( $resolved ), static fn( $block ) => null !== $block['blockName'] ) );
+
+		$this->assertSame( 'core/heading', $blocks[0]['blockName'] );
+		$this->assertStringContainsString( 'Composed title', $resolved );
+		$this->assertSame( 'core/pattern', $blocks[1]['blockName'] );
+		$this->assertSame( $hero, $blocks[1]['attrs']['slug'] );
+		$this->assertSame( array( 'headline' => array( 'content' => 'Section' ) ), $blocks[1]['attrs']['content'] );
+	}
+
+	/**
+	 * `compose()` inlines plain references the way core does, and only those.
+	 */
+	public function test_compose_inlines_plain_references_and_keeps_synced_ones() {
+		$hero  = $this->register_pattern( 'test/hero', $this->bound_heading(), array( 'title' => 'Hero' ) );
+		$plain = $this->register_pattern(
+			'test/plain',
+			'<!-- wp:paragraph --><p>Plain</p><!-- /wp:paragraph -->',
+			array( 'title' => 'Plain' )
+		);
+		$this->mark_synced( $hero );
+
+		$composed = Pattern_Resolver::compose( $this->pattern_block( $plain ) . $this->pattern_block( $hero ) );
+
+		$blocks = array_values( array_filter( parse_blocks( $composed ), static fn( $block ) => null !== $block['blockName'] ) );
+
+		$this->assertCount( 2, $blocks );
+		$this->assertSame( 'core/paragraph', $blocks[0]['blockName'] );
+		$this->assertSame( $plain, $blocks[0]['attrs']['metadata']['patternName'], 'An inlined pattern reads as an instance, as core marks it.' );
+		$this->assertSame( 'Plain', $blocks[0]['attrs']['metadata']['name'] );
+		$this->assertSame( 'core/pattern', $blocks[1]['blockName'] );
+		$this->assertSame( $hero, $blocks[1]['attrs']['slug'] );
+	}
+
+	/**
+	 * `compose()` does not change what `resolve()` does afterwards: a plain
+	 * reference is still left for core there.
+	 */
+	public function test_resolve_still_leaves_plain_references_after_compose() {
+		$plain = $this->register_pattern( 'test/plain', '<!-- wp:paragraph --><p>Plain</p><!-- /wp:paragraph -->' );
+
+		Pattern_Resolver::compose( $this->pattern_block( $plain ) );
+
+		$markup = $this->pattern_block( $plain );
+		$this->assertSame( $markup, Pattern_Resolver::resolve( $markup ) );
+	}
+
+	/**
 	 * A pattern that includes itself is dropped rather than recursing.
 	 */
 	public function test_self_referencing_pattern_is_dropped() {


### PR DESCRIPTION
## Summary

Ports [Twenty-Bellows/synced-patterns-for-themes#7](https://github.com/Twenty-Bellows/synced-patterns-for-themes/pull/7) into the vendored runtime, so the two stay logic-identical. Review them together; the logic and the tests are the same, with only the namespace, package, and hook names differing.

A page whose content is a single reference to an **unsynced** page pattern opened in the editor with the page pattern's synced sections flattened into plain groups and columns: the words right, the design unlocked, the link to the synced pattern files gone. The same page pattern inserted by hand kept its instances, because that path never passed through the server.

- `Pattern_Resolver` composed every pattern block that carried content into plain blocks, synced targets included.
- `Editor_Support` then handed the result to core's `resolve_pattern_blocks()`, which inlines any remaining `core/pattern` block and drops the `content` attribute.

### The change

- **A synced target is never expanded.** The resolver returns the block as written, content and all, and the editor's `SyncedPatternEdit` renders it as an instance with editable slots. It is not returned as null either, since null hands it to core, which would flatten it.
- **Core's resolver is no longer run** over the pattern list. `Pattern_Resolver::compose()` takes that job: content written in, plain references inlined the way core inlines them, synced references kept.
- `resolve()` is unchanged for templates.

No client change. The `content` attribute this plugin registers survives core's `cloneBlock`, and the existing `editor.BlockEdit` filter renders each synced reference as an instance. The front end renders through `Pattern_Block` and is unaffected.

### Files

- `includes/class-pattern-resolver.php`: taken whole from upstream, names substituted.
- `includes/class-editor-support.php`: the same three edits as upstream.
- `tests/php/test-runtime-pattern-resolver.php`, `tests/php/test-runtime-editor-support.php`, `tests/php/class-pattern-test-case.php`: taken whole from upstream, names substituted.

## Test plan

- [x] Every ported file matches upstream after name substitution, except the pre-existing `window.patternBuilder` global in `Editor_Support`
- [x] `composer lint`: no errors in the touched files. The one reported error is pre-existing in `class-pattern-builder-abilities.php`, untouched here
- [x] `php -l` on every touched file
- [ ] `npm run test:php`: not run here, no database in this sandbox
- [ ] On patternbuilderwp.com's theme, seed and open the Features page in the editor: the masthead, feature bands and closing band should appear as `patternbuilderwp/…` instances with editable slots, not as plain groups and columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWfn4hJb2BSiyeCLemmNgg

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWfn4hJb2BSiyeCLemmNgg)_