### PR TITLE
Park the design-comparison tooling for a decision

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -33,6 +33,7 @@
 /src
 /svn
 /tests
+/tools
 /vendor
 /webpack.config.js
 *.zip

--- a/tools/design-comparison/README.md
+++ b/tools/design-comparison/README.md
@@ -1,0 +1,86 @@
+# Design comparison tooling
+
+Two scripts for the question "does what I built match the design I was
+copying?", written after a whole-site rebuild where the answer was checked by
+eye and four separate transcription errors survived to the end.
+
+**These are deliberately not part of the `pattern-author` skill.** The skill
+reaches agents through the abilities, which are JSON in and JSON out; shipping
+scripts through it is a different decision from writing guidance, and this is
+parked here until that decision is made. Nothing in `guides/` references these
+files.
+
+## Why they exist
+
+Reproducing a design fails quietly. A wrong font size, a 4px block gap, a
+button line-height of `inherit` where the original said `1.1` — none of them
+error, none of them look wrong on their own, and all of them are obvious the
+moment you compare numbers instead of pictures.
+
+In the rebuild these two scripts would have caught, in one pass each:
+
+| Error | Caught by |
+|---|---|
+| `elements.button` line-height `inherit` vs `1.1` | design-system diff |
+| Button padding: core's default vs `0.9rem/1.6rem` | design-system diff |
+| Block gap 24px vs 20px | design-system diff |
+| Layout 800/1200 vs 46rem/80rem | design-system diff |
+| Nav links underlined where the source had none | render diff |
+| A heading wrapping to 4 lines instead of 3 | render diff |
+
+## `compare-design-system.mjs`
+
+No browser, no dependencies. Fetches two pages, pulls the
+`global-styles-inline-css` block out of each, and diffs it rule by rule —
+which is the design system exactly as the browser sees it, so a difference
+here is a difference in what was installed rather than in how a pattern used
+it.
+
+```bash
+node tools/design-comparison/compare-design-system.mjs \
+  https://source.example.com/ https://mine.example.com/
+```
+
+Run this **first**. It is cheap, it needs nothing installed, and most
+reproduction errors are design-system errors.
+
+## `compare-render.mjs`
+
+Loads both pages in a browser and compares the *computed* style of every
+element carrying text, matched on the text itself — which works because when
+you are reproducing a design the copy is identical by construction. Reports
+per-property differences, then where the two documents drift apart vertically.
+
+```bash
+npm i --no-save playwright   # or reuse an existing install
+node tools/design-comparison/compare-render.mjs \
+  https://source.example.com/ https://mine.example.com/
+```
+
+Slower and needs Chromium, so it is the second pass: run it once the design
+system agrees, when what is left is how the markup used it.
+
+## What it looks like working
+
+Run against the rebuild that prompted these, `compare-design-system.mjs`
+reduces two 100KB stylesheets to one finding:
+
+```
+:root
+   --wp--style--global--content-size: 46rem   ->   800px
+   --wp--style--global--wide-size: 80rem   ->   1200px
+   (38 properties the source has and mine does not: --wp--preset--color--black, …)
+```
+
+The layout widths are genuinely still wrong on that site; the 38 absent
+properties are core's default palette, which the blank theme strips on purpose.
+Separating "this value differs" from "this side does not have this property at
+all" is what keeps the first visible.
+
+## Known rough edges
+
+- `compare-render.mjs` matches on text, so it is only useful where both pages
+  carry the same copy. That is the reproduction case and not much else.
+- Neither handles authentication.
+- Playwright's `fullPage` screenshot drops images on very tall pages in some
+  headless builds; neither script screenshots, but be aware if you extend them.

--- a/tools/design-comparison/compare-design-system.mjs
+++ b/tools/design-comparison/compare-design-system.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Diff two pages' generated global-styles CSS, rule by rule.
+ *
+ * WordPress writes the whole resolved design system into one inline
+ * stylesheet, so comparing that is comparing the design systems themselves:
+ * a difference here is a difference in what was installed, not in how a
+ * pattern used it. No browser and nothing to install.
+ *
+ *   node compare-design-system.mjs <source-url> <mine-url>
+ */
+
+const ID = 'global-styles-inline-css';
+
+/** The generated global-styles stylesheet, out of a page's HTML. */
+async function stylesheet( url ) {
+	const res = await fetch( url, { redirect: 'follow' } );
+	if ( ! res.ok ) {
+		throw new Error( `${ url } answered ${ res.status }` );
+	}
+	const html = await res.text();
+	const block = new RegExp( `<style[^>]*id=['"]${ ID }['"][^>]*>([\\s\\S]*?)</style>`, 'g' );
+	const found = [ ...html.matchAll( block ) ].map( ( m ) => m[ 1 ] ).join( '\n' );
+
+	if ( ! found ) {
+		throw new Error(
+			`${ url } has no #${ ID }. Either it is not a block theme, or the theme dequeued it.`
+		);
+	}
+	return found;
+}
+
+/**
+ * Compare values as CSS means them, not as they were typed.
+ *
+ * `#17120E` and `#17120e` are the same colour, and a difference in case or in
+ * spacing inside a function is not a finding — reporting it buries the ones
+ * that are.
+ */
+function normalize( value ) {
+	return value
+		.replace( /#[0-9a-f]{3,8}\b/gi, ( hex ) => hex.toLowerCase() )
+		.replace( /\s*,\s*/g, ',' )
+		.replace( /\s+/g, ' ' )
+		.trim();
+}
+
+/** Selector -> { property: value }, flattened across repeated selectors. */
+function rules( css ) {
+	const out = new Map();
+	for ( const m of css.matchAll( /([^{}]+)\{([^{}]*)\}/g ) ) {
+		const selector = m[ 1 ].replace( /\s+/g, ' ' ).trim();
+		const declarations = out.get( selector ) || new Map();
+		for ( const declaration of m[ 2 ].split( ';' ) ) {
+			const at = declaration.indexOf( ':' );
+			if ( at < 1 ) {
+				continue;
+			}
+			declarations.set( declaration.slice( 0, at ).trim(), normalize( declaration.slice( at + 1 ) ) );
+		}
+		if ( declarations.size ) {
+			out.set( selector, declarations );
+		}
+	}
+	return out;
+}
+
+const [ sourceUrl, mineUrl ] = process.argv.slice( 2 );
+
+if ( ! sourceUrl || ! mineUrl ) {
+	console.error( 'usage: compare-design-system.mjs <source-url> <mine-url>' );
+	process.exit( 2 );
+}
+
+const [ source, mine ] = await Promise.all( [
+	stylesheet( sourceUrl ).then( rules ),
+	stylesheet( mineUrl ).then( rules ),
+] );
+
+console.log( `source: ${ source.size } selectors   mine: ${ mine.size } selectors\n` );
+
+let differing = 0;
+
+for ( const [ selector, want ] of source ) {
+	const got = mine.get( selector );
+	if ( ! got ) {
+		continue; // Reported below, as a selector only one side has.
+	}
+
+	/*
+	 * A property whose value differs is nearly always a mistake in the
+	 * reproduction. A property one side does not have at all is usually a
+	 * deliberate difference between the themes — a blank theme strips core's
+	 * default palette — so it is counted rather than listed.
+	 */
+	const changed = [ ...want ].filter(
+		( [ property, value ] ) => got.has( property ) && got.get( property ) !== value
+	);
+	const absent = [ ...want.keys() ].filter( ( property ) => ! got.has( property ) );
+	const added = [ ...got.keys() ].filter( ( property ) => ! want.has( property ) );
+
+	if ( ! changed.length && ! absent.length && ! added.length ) {
+		continue;
+	}
+
+	if ( changed.length ) {
+		differing++;
+	}
+
+	console.log( selector );
+	for ( const [ property, value ] of changed ) {
+		console.log( `   ${ property }: ${ value }   ->   ${ got.get( property ) }` );
+	}
+	if ( absent.length ) {
+		console.log( `   (${ absent.length } propert${ absent.length === 1 ? 'y' : 'ies' } the source has and mine does not: ${ absent.slice( 0, 4 ).join( ', ' ) }${ absent.length > 4 ? ', …' : '' })` );
+	}
+	if ( added.length ) {
+		console.log( `   (${ added.length } only in mine: ${ added.slice( 0, 4 ).join( ', ' ) }${ added.length > 4 ? ', …' : '' })` );
+	}
+	console.log();
+}
+
+const onlySource = [ ...source.keys() ].filter( ( s ) => ! mine.has( s ) );
+const onlyMine = [ ...mine.keys() ].filter( ( s ) => ! source.has( s ) );
+
+console.log( `${ differing } shared selectors have a property whose value differs — those are the findings.` );
+
+/*
+ * A selector on one side only is usually a preset the other does not define —
+ * often core's default palette, which a deliberately blank theme strips. Worth
+ * showing, but it is noise far more often than the shared-selector diff above.
+ */
+for ( const [ label, list ] of [ [ 'only on the source', onlySource ], [ 'only in mine', onlyMine ] ] ) {
+	if ( ! list.length ) {
+		continue;
+	}
+	console.log( `\n${ list.length } selectors ${ label }:` );
+	for ( const selector of list.slice( 0, 25 ) ) {
+		console.log( '   ' + selector.slice( 0, 140 ) );
+	}
+	if ( list.length > 25 ) {
+		console.log( `   … and ${ list.length - 25 } more` );
+	}
+}
+
+process.exit( differing ? 1 : 0 );

--- a/tools/design-comparison/compare-render.mjs
+++ b/tools/design-comparison/compare-render.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Compare two rendered pages by computed style rather than by eye.
+ *
+ * Both pages are loaded at the same width and every element carrying visible
+ * text is recorded with its computed type, colour and box. The two are matched
+ * on the text itself, which is identical by construction when you are
+ * reproducing a design — so nothing has to guess which element corresponds to
+ * which.
+ *
+ *   npm i --no-save playwright
+ *   node compare-render.mjs <source-url> <mine-url> [width]
+ */
+
+import { chromium } from 'playwright';
+
+const FIELDS = [
+	'fontSize',
+	'fontFamily',
+	'fontWeight',
+	'lineHeight',
+	'letterSpacing',
+	'textTransform',
+	'textDecoration',
+	'color',
+	'background',
+];
+
+/** Everything that carries text, with what the browser computed for it. */
+async function collect( page, url ) {
+	await page.goto( url, { waitUntil: 'load', timeout: 60000 } );
+	await page.waitForTimeout( 1200 );
+
+	return page.evaluate( () => {
+		const TEXTUAL = new Set( [
+			'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'P', 'LI', 'A',
+			'TD', 'TH', 'SPAN', 'STRONG', 'EM', 'FIGCAPTION', 'BUTTON',
+		] );
+
+		/* The nearest ancestor that actually paints, so a colour can be judged
+		 * against the ground it sits on rather than against `transparent`. */
+		const painted = ( el ) => {
+			for ( let n = el; n && n !== document.documentElement; n = n.parentElement ) {
+				const bg = getComputedStyle( n ).backgroundColor;
+				if ( bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent' ) {
+					return bg;
+				}
+			}
+			return getComputedStyle( document.body ).backgroundColor;
+		};
+
+		const out = [];
+
+		for ( const el of document.querySelectorAll( '*' ) ) {
+			if ( ! TEXTUAL.has( el.tagName ) ) {
+				continue;
+			}
+
+			// Only the text this element owns, not its descendants' — otherwise
+			// every ancestor matches the same string.
+			const own = Array.from( el.childNodes )
+				.filter( ( n ) => n.nodeType === Node.TEXT_NODE )
+				.map( ( n ) => n.textContent )
+				.join( ' ' )
+				.replace( /\s+/g, ' ' )
+				.trim();
+
+			if ( own.length < 3 ) {
+				continue;
+			}
+
+			const cs = getComputedStyle( el );
+			const box = el.getBoundingClientRect();
+
+			out.push( {
+				text: own.slice( 0, 90 ),
+				tag: el.tagName,
+				fontSize: cs.fontSize,
+				fontFamily: cs.fontFamily.split( ',' )[ 0 ].replace( /["']/g, '' ),
+				fontWeight: cs.fontWeight,
+				lineHeight: cs.lineHeight,
+				letterSpacing: cs.letterSpacing,
+				textTransform: cs.textTransform,
+				textDecoration: cs.textDecorationLine,
+				color: cs.color,
+				background: painted( el ),
+				top: Math.round( box.top + window.scrollY ),
+				width: Math.round( box.width ),
+			} );
+		}
+
+		return { height: document.documentElement.scrollHeight, elements: out };
+	} );
+}
+
+const key = ( e ) => e.text.toLowerCase().replace( /[^a-z0-9 ]/g, '' ).slice( 0, 60 );
+
+const index = ( list ) => {
+	const m = new Map();
+	for ( const e of list ) {
+		const k = key( e );
+		m.set( k, [ ...( m.get( k ) || [] ), e ] );
+	}
+	return m;
+};
+
+const [ sourceUrl, mineUrl, widthArg ] = process.argv.slice( 2 );
+
+if ( ! sourceUrl || ! mineUrl ) {
+	console.error( 'usage: compare-render.mjs <source-url> <mine-url> [width]' );
+	process.exit( 2 );
+}
+
+const width = Number( widthArg || 1400 );
+const browser = await chromium.launch();
+const page = await browser.newPage( { viewport: { width, height: 1000 } } );
+
+const source = await collect( page, sourceUrl );
+const mine = await collect( page, mineUrl );
+await browser.close();
+
+const sourceIndex = index( source.elements );
+const mineIndex = index( mine.elements );
+
+const differences = [];
+const drift = [];
+const missing = [];
+let matched = 0;
+
+for ( const [ k, wanted ] of sourceIndex ) {
+	const got = mineIndex.get( k );
+	if ( ! got ) {
+		missing.push( wanted[ 0 ].text );
+		continue;
+	}
+	matched++;
+
+	// Every occurrence, not just the first: the same words appear on bands with
+	// different grounds, and taking one hides the others.
+	for ( let i = 0; i < Math.min( wanted.length, got.length ); i++ ) {
+		const a = wanted[ i ];
+		const b = got[ i ];
+		const label = a.text + ( wanted.length > 1 ? ` [${ i + 1 }/${ wanted.length }]` : '' );
+
+		const wrong = FIELDS.filter( ( f ) => a[ f ] !== b[ f ] );
+		if ( wrong.length ) {
+			differences.push( { label, tag: a.tag, wrong: wrong.map( ( f ) => `${ f }: ${ a[ f ] }  ->  ${ b[ f ] }` ) } );
+		}
+		if ( Math.abs( a.top - b.top ) > 4 || Math.abs( a.width - b.width ) > 4 ) {
+			drift.push( { label, tag: a.tag, srcTop: a.top, mineTop: b.top, dy: b.top - a.top, srcW: a.width, mineW: b.width } );
+		}
+	}
+}
+
+console.log( `page height   source ${ source.height }px   mine ${ mine.height }px` );
+console.log( `matched ${ matched } of ${ sourceIndex.size } source strings; ${ missing.length } not found in mine` );
+console.log( `${ differences.length } elements differ on at least one computed property\n` );
+
+for ( const d of differences.slice( 0, 40 ) ) {
+	console.log( `  ${ d.tag }  "${ d.label.slice( 0, 60 ) }"` );
+	for ( const line of d.wrong ) {
+		console.log( `      ${ line }` );
+	}
+}
+
+if ( missing.length ) {
+	console.log( '\nNot found in mine:' );
+	for ( const t of missing.slice( 0, 20 ) ) {
+		console.log( '  - ' + t.slice( 0, 70 ) );
+	}
+}
+
+/* Only where the running offset changes — that is where a band grew or shrank,
+ * rather than everything downstream of it repeating the same number. */
+if ( drift.length ) {
+	console.log( `\n${ drift.length } elements sit at a different position or width; where it changes:` );
+	drift.sort( ( a, b ) => a.srcTop - b.srcTop );
+	let last = 0;
+	for ( const d of drift ) {
+		if ( Math.abs( d.dy - last ) > 3 || Math.abs( d.srcW - d.mineW ) > 4 ) {
+			console.log(
+				`  y ${ String( d.srcTop ).padStart( 5 ) } -> ${ String( d.mineTop ).padStart( 5 ) }` +
+					`  (dy ${ d.dy > 0 ? '+' : '' }${ d.dy })  w ${ d.srcW } -> ${ d.mineW }   ${ d.tag } "${ d.label.slice( 0, 45 ) }"`
+			);
+			last = d.dy;
+		}
+	}
+}
+
+process.exit( differences.length || missing.length ? 1 : 0 );


### PR DESCRIPTION
Parked for you to look at later, as discussed — **nothing in `guides/` references these and `.distignore` keeps `tools/` out of the wp.org build.** The `pattern-author` skill reaches agents through the abilities, which are JSON in and JSON out; whether scripts should travel that way is a separate decision from writing guidance, and this branch exists so the tooling isn't lost while that's open.

## What they are

Two scripts for "does what I built match the design I was copying?", written after a four-page rebuild where that got checked by eye at the very end and four transcription errors survived to it: `elements.button` line-height `inherit` where the source said `1.1`, core's default button padding against `0.9rem/1.6rem`, a 24px block gap against 20px, and the layout widths.

**`compare-design-system.mjs`** — no browser, nothing to install. Pulls the `global-styles-inline-css` block out of two pages and diffs it rule by rule. That stylesheet is the design system exactly as the browser sees it, so a difference there is a difference in what was *installed* rather than in how a pattern used it. All four errors above are in its first screen of output.

Two things make the output usable rather than a wall:

- Values are compared as CSS means them — `#17120E` and `#17120e` is not a finding.
- A property one side simply lacks is *counted*, not listed, and kept separate from a property whose value differs. The first is usually a deliberate difference between two themes (a blank theme strips core's palette); the second is nearly always a mistake. Mixing them buried the mistakes.

Run against the site that prompted this, it reduces two 100KB stylesheets to one finding:

```
:root
   --wp--style--global--content-size: 46rem   ->   800px
   --wp--style--global--wide-size: 80rem   ->   1200px
   (38 properties the source has and mine does not: --wp--preset--color--black, …)
```

Which is correct — those widths are genuinely still wrong on that site, because `set-layout` didn't exist when it was built.

**`compare-render.mjs`** — the second pass, once the design system agrees. Loads both pages in Playwright and compares the computed style of every element carrying text, matched on the text itself. That works because when you're reproducing a design the copy is identical by construction, so nothing has to guess which element corresponds to which. Reports per-property differences, then where the two documents drift apart vertically.

## If you'd rather they lived somewhere else

The obvious alternatives, in rough order of how much they'd change:

1. **Leave them here** as developer tooling, undocumented in the skill — the current state.
2. **A `get-design-system-diff` ability** that takes a URL and diffs that page's stylesheet against this site's. Server-side PHP, no script shipped; the cost is an outbound fetch to a caller-supplied URL, which is a security question worth its own conversation.
3. **A separate repo or gist**, if this doesn't belong in the plugin at all.

I'd lean 2 for the design-system half — it's genuinely useful over the wire and needs no browser — and 1 or 3 for the render half, which can't escape needing Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fr6uocsyi8N5b5YejYjcs

---
_Generated by [Claude Code](https://claude.ai/code/session_017Fr6uocsyi8N5b5YejYjcs)_