### PR TITLE
Remove an optional element when its slot is filled with nothing

### DIFF
--- a/includes/class-block-markup.php
+++ b/includes/class-block-markup.php
@@ -22,6 +22,24 @@ use WP_HTML_Tag_Processor;
 class Block_Markup {
 
 	/**
+	 * Elements a block's `save()` leaves out rather than writing empty.
+	 *
+	 * Writing an empty value into an element-sourced attribute has to end up
+	 * with the markup that block would have saved, and for most of them that is
+	 * the element with nothing inside it: `core/paragraph` writes `<p></p>`,
+	 * `core/button` an empty `<a>`, `core/code` an empty `<code>`. These two are
+	 * the exceptions. Core wraps them in an emptiness check, so an empty value
+	 * means no element at all, and an empty one left behind is markup no version
+	 * of the block would write — which the editor reports as invalid content the
+	 * moment the surrounding bindings are resolved away.
+	 *
+	 * `figcaption` covers `core/image`, `core/audio` and `core/video`; `cite`
+	 * covers `core/quote` and `core/pullquote`. Of those only `core/image`'s
+	 * caption can be bound today, which is how this was found.
+	 */
+	const OPTIONAL_ELEMENTS = array( 'figcaption', 'cite' );
+
+	/**
 	 * Sets an attribute's value on a parsed block.
 	 *
 	 * Returns the block unchanged when the value cannot be written, which keeps
@@ -66,11 +84,13 @@ class Block_Markup {
 		switch ( $definition['source'] ) {
 			case 'html':
 			case 'rich-text':
-				$updated = Inner_HTML_Processor::replace_inner_html(
-					$markup,
-					$selectors,
-					wp_kses_post( (string) $value )
-				);
+				$updated = '' === (string) $value && self::elements_are_optional( $selectors )
+					? Inner_HTML_Processor::remove_element( $markup, $selectors )
+					: Inner_HTML_Processor::replace_inner_html(
+						$markup,
+						$selectors,
+						wp_kses_post( (string) $value )
+					);
 				break;
 
 			case 'attribute':
@@ -152,6 +172,31 @@ class Block_Markup {
 		}
 
 		return $tags;
+	}
+
+	/**
+	 * Whether an empty value means removing these elements rather than emptying them.
+	 *
+	 * Every selector has to be one of the optional elements. A block whose
+	 * attribute can land in more than one place — `core/button`'s text, in an
+	 * `a` or a `button` — is structural in both, and nothing in
+	 * `OPTIONAL_ELEMENTS` shares a selector list with an element like that.
+	 *
+	 * @param string[] $selectors Tag names from the attribute's schema.
+	 * @return bool Whether all of them are elements `save()` omits when empty.
+	 */
+	private static function elements_are_optional( array $selectors ): bool {
+		if ( empty( $selectors ) ) {
+			return false;
+		}
+
+		foreach ( $selectors as $tag ) {
+			if ( ! in_array( strtolower( $tag ), self::OPTIONAL_ELEMENTS, true ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/class-inner-html-processor.php
+++ b/includes/class-inner-html-processor.php
@@ -53,14 +53,90 @@ class Inner_HTML_Processor extends WP_HTML_Processor {
 	}
 
 	/**
+	 * Removes the first element matching one of the selectors, tags and all.
+	 *
+	 * An element a block's `save()` omits when its value is empty — a caption,
+	 * a citation — has to go away entirely rather than be left standing empty,
+	 * or the markup stops being anything the block would have written.
+	 *
+	 * @param string   $html      HTML to update.
+	 * @param string[] $selectors Tag names to look for, in order.
+	 * @return string|null The updated HTML, or null if nothing was removed.
+	 */
+	public static function remove_element( string $html, array $selectors ): ?string {
+		foreach ( $selectors as $tag ) {
+			$processor = static::create_fragment( $html );
+
+			if ( ! $processor instanceof self ) {
+				return null;
+			}
+
+			if ( $processor->next_tag( array( 'tag_name' => $tag ) ) && $processor->delete_element() ) {
+				return $processor->get_updated_html();
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Replaces the content between the current tag and its matching closer.
 	 *
 	 * @param string $html HTML to put inside the element.
 	 * @return bool Whether the content was replaced.
 	 */
 	private function set_inner_html( string $html ): bool {
-		if ( $this->is_tag_closer() || ! $this->expects_closer() ) {
+		$bounds = $this->element_bounds();
+
+		if ( null === $bounds ) {
 			return false;
+		}
+
+		list( $opener, $closer ) = $bounds;
+
+		$start = $opener->start + $opener->length;
+
+		$this->lexical_updates[] = new WP_HTML_Text_Replacement( $start, $closer->start - $start, $html );
+
+		return true;
+	}
+
+	/**
+	 * Removes the current element, its opening and closing tags included.
+	 *
+	 * @return bool Whether the element was removed.
+	 */
+	private function delete_element(): bool {
+		$bounds = $this->element_bounds();
+
+		if ( null === $bounds ) {
+			return false;
+		}
+
+		list( $opener, $closer ) = $bounds;
+
+		$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+			$opener->start,
+			( $closer->start + $closer->length ) - $opener->start,
+			''
+		);
+
+		return true;
+	}
+
+	/**
+	 * Finds where the current element opens and closes in the source HTML.
+	 *
+	 * Leaves the processor sitting on the closing tag, which is what both
+	 * callers want and neither needs to walk back from.
+	 *
+	 * @return WP_HTML_Span[]|null The opening and closing spans, or null when
+	 *                             the current token is not an element with a
+	 *                             closer of its own.
+	 */
+	private function element_bounds(): ?array {
+		if ( $this->is_tag_closer() || ! $this->expects_closer() ) {
+			return null;
 		}
 
 		$depth    = $this->get_current_depth();
@@ -69,10 +145,8 @@ class Inner_HTML_Processor extends WP_HTML_Processor {
 		$opener = $this->mark_current_token();
 
 		if ( null === $opener ) {
-			return false;
+			return null;
 		}
-
-		$start = $opener->start + $opener->length;
 
 		// Walk out of the element. The token left behind is its closer.
 		while ( $this->next_token() && $this->get_current_depth() >= $depth ) {
@@ -80,18 +154,16 @@ class Inner_HTML_Processor extends WP_HTML_Processor {
 		}
 
 		if ( ! $this->is_tag_closer() || $tag_name !== $this->get_tag() ) {
-			return false;
+			return null;
 		}
 
 		$closer = $this->mark_current_token();
 
 		if ( null === $closer ) {
-			return false;
+			return null;
 		}
 
-		$this->lexical_updates[] = new WP_HTML_Text_Replacement( $start, $closer->start - $start, $html );
-
-		return true;
+		return array( $opener, $closer );
 	}
 
 	/**

--- a/tests/php/test-runtime-pattern-resolver.php
+++ b/tests/php/test-runtime-pattern-resolver.php
@@ -379,4 +379,134 @@ class Test_Pattern_Resolver extends Pattern_Test_Case {
 		$this->assertStringContainsString( 'Default headline', $resolved );
 		$this->assertStringNotContainsString( 'Should not appear', $resolved );
 	}
+
+	/**
+	 * Emptying a caption takes the `figcaption` with it.
+	 *
+	 * `core/image` only writes the element when there is something to put in
+	 * it, so an empty one left behind is markup no version of the block would
+	 * save. Resolving strips the bindings that would have excused it, and the
+	 * editor then reports the block as invalid.
+	 */
+	public function test_empty_caption_removes_the_figcaption() {
+		$slug = $this->register_pattern(
+			'test/photo',
+			'<!-- wp:image {"metadata":{"name":"photo","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->'
+			. '<figure class="wp-block-image"><img src="https://example.org/default.png" alt="Default alt"/>'
+			. '<figcaption class="wp-element-caption">Default caption</figcaption></figure>'
+			. '<!-- /wp:image -->'
+		);
+
+		$resolved = Pattern_Resolver::resolve(
+			$this->pattern_block(
+				$slug,
+				array(
+					'photo' => array(
+						'url'     => 'https://example.org/filled.png',
+						'alt'     => 'Filled alt',
+						'caption' => '',
+					),
+				)
+			)
+		);
+
+		$this->assertStringNotContainsString( 'figcaption', $resolved );
+		$this->assertStringNotContainsString( 'Default caption', $resolved );
+		$this->assertStringContainsString( '<img src="https://example.org/filled.png" alt="Filled alt"/>', $resolved );
+		$this->assertStringContainsString( '</figure>', $resolved );
+	}
+
+	/**
+	 * A caption that has something in it is still written in place.
+	 */
+	public function test_caption_with_a_value_is_written_into_the_figcaption() {
+		$slug = $this->register_pattern(
+			'test/photo',
+			'<!-- wp:image {"metadata":{"name":"photo","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->'
+			. '<figure class="wp-block-image"><img src="https://example.org/default.png" alt="Default alt"/>'
+			. '<figcaption class="wp-element-caption">Default caption</figcaption></figure>'
+			. '<!-- /wp:image -->'
+		);
+
+		$resolved = Pattern_Resolver::resolve(
+			$this->pattern_block( $slug, array( 'photo' => array( 'caption' => 'Filled caption' ) ) )
+		);
+
+		$this->assertStringContainsString( '<figcaption class="wp-element-caption">Filled caption</figcaption>', $resolved );
+		$this->assertStringNotContainsString( 'Default caption', $resolved );
+	}
+
+	/**
+	 * An image with no caption to begin with is left exactly as it was.
+	 */
+	public function test_empty_caption_on_an_image_without_one_changes_nothing() {
+		$slug = $this->register_pattern(
+			'test/photo',
+			'<!-- wp:image {"metadata":{"name":"photo","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->'
+			. '<figure class="wp-block-image"><img src="https://example.org/default.png" alt="Default alt"/></figure>'
+			. '<!-- /wp:image -->'
+		);
+
+		$resolved = Pattern_Resolver::resolve(
+			$this->pattern_block(
+				$slug,
+				array(
+					'photo' => array(
+						'alt'     => 'Filled alt',
+						'caption' => '',
+					),
+				)
+			)
+		);
+
+		$this->assertStringContainsString( '<figure class="wp-block-image">', $resolved );
+		$this->assertStringContainsString( 'alt="Filled alt"', $resolved );
+		$this->assertStringNotContainsString( 'figcaption', $resolved );
+	}
+
+	/**
+	 * An element the block would have saved empty is emptied, not removed.
+	 *
+	 * `core/button` writes its `a` whether or not there is a label in it, so
+	 * the rule that removes an empty caption must not reach this far. Losing
+	 * the anchor would take the block's link, its classes and its styling with
+	 * it.
+	 */
+	public function test_empty_button_text_keeps_the_anchor() {
+		$slug = $this->register_pattern(
+			'test/cta',
+			'<!-- wp:button {"metadata":{"name":"cta","bindings":{"text":{"source":"core/pattern-overrides"}}}} -->'
+			. '<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://example.org/old">Old label</a></div>'
+			. '<!-- /wp:button -->'
+		);
+
+		$resolved = Pattern_Resolver::resolve(
+			$this->pattern_block( $slug, array( 'cta' => array( 'text' => '' ) ) )
+		);
+
+		$this->assertStringContainsString(
+			'<a class="wp-block-button__link wp-element-button" href="https://example.org/old"></a>',
+			$resolved
+		);
+		$this->assertStringNotContainsString( 'Old label', $resolved );
+	}
+
+	/**
+	 * The same, for a paragraph, whose `p` is the block itself.
+	 */
+	public function test_empty_paragraph_content_keeps_the_paragraph() {
+		$slug = $this->register_pattern(
+			'test/hero',
+			'<!-- wp:paragraph {"metadata":{"name":"lede","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->'
+			. '<p>Default lede</p>'
+			. '<!-- /wp:paragraph -->'
+		);
+
+		$resolved = Pattern_Resolver::resolve(
+			$this->pattern_block( $slug, array( 'lede' => array( 'content' => '' ) ) )
+		);
+
+		$this->assertStringContainsString( '<p></p>', $resolved );
+		$this->assertStringNotContainsString( 'Default lede', $resolved );
+	}
 }


### PR DESCRIPTION
Vendored from synced-patterns-for-themes, byte-identical apart from the namespace and the bookmark constant.

An overridable image whose caption is set to an empty string came out of `Pattern_Resolver` as `<figcaption class="wp-element-caption"></figcaption>` — `Block_Markup::set_attribute()` emptied the element rather than removing it. `core/image` only writes that element when there is something to put in it, so what was left is markup no version of the block would save.

Resolving is what makes it visible: core treats a block carrying Pattern Overrides bindings as valid whatever its markup says, and `fill_slots()` strips those bindings once it has written the values. The pattern file passes every check the plugin runs — `blockValidity.js` and `validate-pattern.mjs` both exempt a bound block — and the composed block the editor opens is the one that fails.

Emptying stays right for every other element-sourced attribute: `core/paragraph` saves `<p></p>`, `core/button` an empty `<a>`. Only `figcaption` and `cite` are wrapped in an emptiness check across the whole block library, and of those only an image's caption can be bound today.

Upstream: Twenty-Bellows/synced-patterns-for-themes#8