### PR TITLE
Gate collections on Pro and publishing on the grant; the Community tab becomes Directory

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ Pattern Metadata panel.
 ## The browse page
 
 Appearance → Pattern Builder is a Site-Editor-style library: a header with four
-collection tabs (User, Theme, Uploaded, Community — the last two served by the
+collection tabs (User, Theme, Uploaded, Directory — the last two served by the
 cloud browser), each with its own search and category rail, over a grid of
 fixed-size square tiles, plus an always-present details sidebar whose Save and
 Edit actions sit above the same panels the editor shows.

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -6,7 +6,7 @@ How collections work in the plugin. The service side — definitions, tiers, dat
 
 A **collection** is the unit of organisation, publishing and installation on the cloud. Every uploaded pattern is in exactly one; every account has a locked private **Personal** collection; and **Pattern Builder is the only way to install anything** — a single pattern or a whole collection — for people and for agents. In the plugin that means:
 
-- **Community tab**: collections first. Open one, save one pattern or save the whole collection.
+- **Directory tab**: collections first — the collections Twenty Bellows and partner studios publish. Open one, save one pattern or save the whole collection.
 - **Uploaded tab**: your collections, managed here and nowhere else. Upload asks which one.
 - **Installed patterns** land under a local pattern category named for the collection they came from.
 - **Agents** get abilities for all of it, through the connection the WordPress user made.
@@ -30,10 +30,10 @@ Every route stays nonce- and capability-gated and answers 401 disconnected, as t
 | `GET /cloud/collections/{owner}/{slug}` | One collection with its pattern summaries (tokens included, so the union check needs no second pass). |
 | `GET /cloud/directory` | Unchanged; gains `collection` filter. |
 | `POST /cloud/download` | Unchanged: one cloud pattern into theme or user, with tokens. Gains `collection` in the request so the porter can file it. |
-| `GET /cloud/library/collections` · `POST` · `PUT /{id}` · `DELETE /{id}` | The account's collections. Create relays the service's rule (free: public only). Delete takes the collection's patterns with it — there is nowhere to move them (D38). |
+| `GET /cloud/library/collections` · `POST` · `PUT /{id}` · `DELETE /{id}` | The account's collections. Create relays the service's rule (collections of your own are Pro; public only for a publisher; private is the default). Delete takes the collection's patterns with it — there is nowhere to move them (D38). |
 | `GET /cloud/library` | Unchanged; gains `collection` filter. |
 | `POST /cloud/upload` | Gains `collection` (required; `personal` accepted). |
-| `GET /cloud/status` | `/me` relayed; now carries `entitlements` (personal cap, can_create_private, fair use), `personal { count, cap }` and `over_policy`. |
+| `GET /cloud/status` | `/me` relayed; now carries `entitlements` (personal cap, `can_create_collections`, `can_publish`, fair use), `personal { count, cap }` and `over_policy`. |
 | `GET /cloud/pattern-state` | Whether the pattern's `Cloud:` reference is in the connected account's library, asked of the service by name; the answer names the collection. With `name`, which local pattern answers to that cloud name. |
 | `GET /cloud/installed` | Every cloud name a pattern on this site answers to — what a collection tile counts. |
 
@@ -41,7 +41,7 @@ Every route stays nonce- and capability-gated and answers 401 disconnected, as t
 
 **Installing a collection** is one PHP method used by the REST route and by the ability alike: `Pattern_Builder_Cloud_Porter::install_collection( $owner, $slug, $destination, $tokens )` fetches the collection, then imports each pattern in turn through the existing single-pattern path, skipping ones already here under their cloud name, collecting per-pattern results, and never stopping on one failure. The browser calls `POST /cloud/download` per pattern itself so it can show progress; the ability calls the method.
 
-## 3. Community tab (`src/cloud/`)
+## 3. Directory tab (`src/cloud/`)
 
 - **Landing**: a grid of **collection tiles** — a collage of up to four of the collection's previews rendered the way pattern tiles are (fixed design width, scaled), title, owner, count, and a Premium badge. The collections rail goes; the landing *is* the collections.
 - **Search** shows two groups: matching collections as a row of tiles, then matching patterns as the existing grid, each pattern labelled with its collection.
@@ -53,9 +53,9 @@ Every route stays nonce- and capability-gated and answers 401 disconnected, as t
 ## 4. Uploaded tab
 
 - **Rail**: the account's collections, Personal first with a lock icon and its meter ("7 of 25", or the count alone on Pro). Selecting one filters the grid.
-- **New collection**: name, slug (permanent — part of the name of every pattern in the collection), description; visibility only where the account may choose (Pro). A free account is told, in the same dialog, that the collection will be public and why.
-- **Collection header**: Rename, Describe, Visibility (as allowed; Personal offers only Describe), **Delete**, which says plainly that the collection's patterns go with it and offers no alternative — a move would rewrite the middle segment of a permanent name (D38), so the work is downloaded first or not at all.
-- **Over policy** (a lapsed Pro): a banner from `/me` saying what is locked and the three ways out, matching the service's rule.
+- **New collection**: name, slug (permanent — part of the name of every pattern in the collection), description; visibility only for a publisher, private otherwise. A free account is told, in place of the form, that collections of its own are a Pro feature, with Go Pro.
+- **Collection header**: Rename, Describe, Visibility (for a publisher, or to take an inherited public collection private; Personal offers only Describe), **Delete**, which says plainly that the collection's patterns go with it and offers no alternative — a move would rewrite the middle segment of a permanent name (D38), so the work is downloaded first or not at all.
+- **Over policy** (a lapsed Pro): a banner from `/me` saying what is locked and the way out — delete, or go Pro — matching the service's rule.
 
 ## 5. Upload (`PatternCloudPanel`, inside the Pattern Source panel)
 
@@ -77,7 +77,7 @@ All run as the WordPress user the application password names and use that user's
 | `install-collection` | POST | `owner` + `slug`, `destination` (`theme`\|`user`), `tokens` (`add`\|`skip`) → per-pattern results |
 | `install-cloud-pattern` | POST | `id`, `destination`, `tokens` → the local pattern |
 | `upload-pattern` | POST | a local pattern `id` (or `title` + `content`), `collection` (default `personal`) → the cloud pattern and its state |
-| `create-collection` | POST | `name`, `description` → the collection. Always private; on a free account the service refuses with the upgrade message, since an agent never publishes |
+| `create-collection` | POST | `name`, `description` → the collection. Always private; on a free account the service refuses with the upgrade message, since collections of your own are Pro, and an agent never publishes |
 
 No ability changes visibility or deletes a collection. The authoring guide's `abilities.md` gains the seven, and the guide index's `validate` block still names what to run before `upload-pattern`.
 

--- a/guides/pattern-author/references/abilities.md
+++ b/guides/pattern-author/references/abilities.md
@@ -260,19 +260,20 @@ patternbuilderwp.com account on this site first" — which is for a person to
 do on the Pattern Builder screen, not for you.
 
 A **collection** is the unit there: every cloud pattern is in exactly one,
-every account has a locked private **Personal**, and a collection is public or
-private as a whole. Installing puts each pattern under a local pattern
+every account has a locked private **Personal**, and a collection is private
+unless Twenty Bellows or a partner publisher has made it public. Installing
+puts each pattern under a local pattern
 category named for its collection.
 
 | Name | Method | Purpose |
 |---|---|---|
-| `pattern-builder/list-collections` | GET | the community's public and premium collections (`input[scope]=community`, the default; `input[search]`), or the account's own, Personal first (`input[scope]=mine`) |
-| `pattern-builder/get-collection` | GET | one collection with its pattern summaries, each marked `installed` when this site already has it. `input[owner]` + `input[slug]` for a community collection, `input[id]` for one of the account's own |
+| `pattern-builder/list-collections` | GET | the directory's public and premium collections (`input[scope]=community`, the default; `input[search]`), or the account's own, Personal first (`input[scope]=mine`) |
+| `pattern-builder/get-collection` | GET | one collection with its pattern summaries, each marked `installed` when this site already has it. `input[owner]` + `input[slug]` for a directory collection, `input[id]` for one of the account's own |
 | `pattern-builder/search-cloud-patterns` | GET | search public patterns by `input[search]`; each names its collection; `input[collection]=owner/slug` narrows to one |
 | `pattern-builder/install-collection` | POST | every pattern of a collection, in one action: `owner`, `slug`, `destination` (`theme`\|`user`, default user), `tokens` (`add`\|`skip`, default add). Already-installed patterns are skipped, a failure is reported and the rest carry on; per-pattern results come back |
 | `pattern-builder/install-cloud-pattern` | POST | one pattern by `id`, with the same `destination` and `tokens`; `source` is `directory` (default) or `library` |
 | `pattern-builder/upload-pattern` | POST | a local pattern (`id`) or finished markup (`title` + `content`, stored here as a user pattern first) into `collection` — an id, or `personal` (the default), read on a pattern's first upload only. A pattern that references others takes them with it, and `members` lists everything that went up; a reference to a pattern this site does not have refuses the upload by name. Validate first, as for create-pattern |
-| `pattern-builder/create-collection` | POST | a **private** collection: `name`, `description`. On a free account the service refuses with an upgrade message, since free accounts only make public collections and an agent never publishes; upload into Personal instead |
+| `pattern-builder/create-collection` | POST | a **private** collection: `name`, `description`. On a free account the service refuses with an upgrade message, since collections of your own are a Pro feature; an agent never publishes. Upload into Personal instead |
 
 No ability makes a collection public, changes a visibility, or deletes a
 collection. Those are the account holder's, in Pattern Builder.

--- a/includes/class-pattern-builder-cloud-abilities.php
+++ b/includes/class-pattern-builder-cloud-abilities.php
@@ -161,7 +161,7 @@ class Pattern_Builder_Cloud_Abilities {
 			'pattern-builder/list-collections',
 			array(
 				'label'               => __( 'List cloud collections', 'pattern-builder' ),
-				'description'         => __( 'Lists collections on patternbuilderwp.com through this site’s connection: the community’s public and premium collections (scope "community", the default), or the connected account’s own, Personal first (scope "mine"). Each carries its owner, count, visibility and, for the community, a public URL. Requires the WordPress user to have connected Pattern Builder to a patternbuilderwp.com account.', 'pattern-builder' ),
+				'description'         => __( 'Lists collections on patternbuilderwp.com through this site’s connection: the directory’s public and premium collections (scope "community", the default), or the connected account’s own, Personal first (scope "mine"). Each carries its owner, count, visibility and, for the directory, a public URL. Requires the WordPress user to have connected Pattern Builder to a patternbuilderwp.com account.', 'pattern-builder' ),
 				'category'            => Pattern_Builder_Abilities::CATEGORY,
 				'input_schema'        => array(
 					'type'                 => 'object',
@@ -172,7 +172,7 @@ class Pattern_Builder_Cloud_Abilities {
 						),
 						'search' => array(
 							'type'        => 'string',
-							'description' => 'Community only: match collection titles and descriptions.',
+							'description' => 'Directory only: match collection titles and descriptions.',
 						),
 						'page'   => array( 'type' => 'integer' ),
 					),
@@ -320,7 +320,7 @@ class Pattern_Builder_Cloud_Abilities {
 	}
 
 	/**
-	 * Search the community's patterns.
+	 * Search the directory's patterns.
 	 */
 	private function register_search_cloud_patterns() {
 		wp_register_ability(
@@ -399,7 +399,7 @@ class Pattern_Builder_Cloud_Abilities {
 			'pattern-builder/install-collection',
 			array(
 				'label'               => __( 'Install a cloud collection', 'pattern-builder' ),
-				'description'         => __( 'Installs every pattern of a community collection onto this site in one action, as theme patterns or user patterns, images included and under a local pattern category named for the collection. Patterns already installed from it are skipped; a failure is reported and the rest carry on. A premium collection needs a Pattern Builder Pro account. Returns per-pattern results.', 'pattern-builder' ),
+				'description'         => __( 'Installs every pattern of a directory collection onto this site in one action, as theme patterns or user patterns, images included and under a local pattern category named for the collection. Patterns already installed from it are skipped; a failure is reported and the rest carry on. A premium collection needs a Pattern Builder Pro account. Returns per-pattern results.', 'pattern-builder' ),
 				'category'            => Pattern_Builder_Abilities::CATEGORY,
 				'input_schema'        => array(
 					'type'                 => 'object',
@@ -463,7 +463,7 @@ class Pattern_Builder_Cloud_Abilities {
 			'pattern-builder/install-cloud-pattern',
 			array(
 				'label'               => __( 'Install a cloud pattern', 'pattern-builder' ),
-				'description'         => __( 'Installs one pattern from patternbuilderwp.com onto this site, as a theme pattern or a user pattern, images included. A community pattern lands under a local category named for its collection; one from the connected account’s own library (source "library") does not. Returns the local pattern.', 'pattern-builder' ),
+				'description'         => __( 'Installs one pattern from patternbuilderwp.com onto this site, as a theme pattern or a user pattern, images included. A directory pattern lands under a local category named for its collection; one from the connected account’s own library (source "library") does not. Returns the local pattern.', 'pattern-builder' ),
 				'category'            => Pattern_Builder_Abilities::CATEGORY,
 				'input_schema'        => array(
 					'type'                 => 'object',
@@ -476,7 +476,7 @@ class Pattern_Builder_Cloud_Abilities {
 							'source' => array(
 								'type'        => 'string',
 								'enum'        => array( 'directory', 'library' ),
-								'description' => 'Where the pattern lives: the community directory (default), or the connected account’s own library.',
+								'description' => 'Where the pattern lives: the directory (default), or the connected account’s own library.',
 							),
 						),
 						$this->install_properties()
@@ -652,7 +652,7 @@ class Pattern_Builder_Cloud_Abilities {
 			'pattern-builder/create-collection',
 			array(
 				'label'               => __( 'Create a cloud collection', 'pattern-builder' ),
-				'description'         => __( 'Creates a private collection on the connected account. The slug is permanent and becomes part of the name of every pattern in the collection ({handle}/{collection}/{pattern}), so choose it deliberately: it cannot be changed, only replaced by making another collection. Always private: an agent never publishes, and nothing here makes a collection public, changes a visibility or deletes one — the account holder does that in Pattern Builder. On a free account the service refuses with an upgrade message, since free accounts only create public collections; upload into Personal instead.', 'pattern-builder' ),
+				'description'         => __( 'Creates a private collection on the connected account. The slug is permanent and becomes part of the name of every pattern in the collection ({handle}/{collection}/{pattern}), so choose it deliberately: it cannot be changed, only replaced by making another collection. Private, as every collection is unless a publisher makes it public: an agent never publishes, and nothing here makes a collection public, changes a visibility or deletes one — the account holder does that in Pattern Builder. On a free account the service refuses with an upgrade message, since collections of your own are a Pattern Builder Pro feature; upload into Personal instead.', 'pattern-builder' ),
 				'category'            => Pattern_Builder_Abilities::CATEGORY,
 				'input_schema'        => array(
 					'type'                 => 'object',

--- a/includes/class-pattern-builder-cloud-controller.php
+++ b/includes/class-pattern-builder-cloud-controller.php
@@ -355,7 +355,7 @@ class Pattern_Builder_Cloud_Controller {
 	}
 
 	/**
-	 * The community is browsed as an account.
+	 * The directory is browsed as an account.
 	 *
 	 * @return true|WP_Error
 	 */
@@ -363,7 +363,7 @@ class Pattern_Builder_Cloud_Controller {
 		if ( Pattern_Builder_Cloud::is_connected() ) {
 			return true;
 		}
-		return new WP_Error( 'pb_cloud_disconnected', __( 'Sign in to patternbuilderwp.com to browse community patterns.', 'pattern-builder' ), array( 'status' => 401 ) );
+		return new WP_Error( 'pb_cloud_disconnected', __( 'Sign in to patternbuilderwp.com to browse the directory.', 'pattern-builder' ), array( 'status' => 401 ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -28,8 +28,8 @@ Pattern Builder transforms how you work with WordPress block patterns, providing
 * **Sync Status** - Manage synced and unsynced patterns effortlessly
 
 **Your Patterns, on Every Site**
-* **Collections** - Keep patterns on patternbuilderwp.com in collections: a private Personal for yourself, public ones for the community
-* **Install a whole collection** - Save any community collection to a site in one action, as theme patterns or user patterns, images included
+* **Collections** - Keep patterns on patternbuilderwp.com in collections: a private Personal for yourself, private collections of your own on Pro, and the curated collections Twenty Bellows and partner studios publish
+* **Install a whole collection** - Save any directory collection to a site in one action, as theme patterns or user patterns, images included
 * **Agents welcome** - An agent connected to your site can browse, install and upload through your account, and never holds a cloud credential
 
 **Developer-Friendly**
@@ -86,7 +86,7 @@ Pattern Builder transforms how you work with WordPress block patterns, providing
 
 Everything local works without an account and without sending anything anywhere. Three services are involved only when you choose to use them:
 
-**patternbuilderwp.com** — the cloud library and community directory, and the account behind them. When you sign in or create an account from Appearance → Pattern Builder, your email and password are relayed once, server-side, to patternbuilderwp.com; only the returned access token is stored, on this site, for your WordPress user. Browsing the Uploaded and Community tabs, managing your collections, uploading patterns and installing patterns or whole collections, starting a password reset, and confirming a purchase all talk to patternbuilderwp.com through this site. Pattern Builder is the only way to install anything from patternbuilderwp.com: the website shows collections and sends people here. Anonymous usage reporting, if you allow it, goes there too (see below). Terms: https://patternbuilderwp.com/terms/ — Privacy: https://patternbuilderwp.com/privacy/
+**patternbuilderwp.com** — the cloud library and its directory of curated collections, and the account behind them. When you sign in or create an account from Appearance → Pattern Builder, your email and password are relayed once, server-side, to patternbuilderwp.com; only the returned access token is stored, on this site, for your WordPress user. Browsing the Uploaded and Directory tabs, managing your collections, uploading patterns and installing patterns or whole collections, starting a password reset, and confirming a purchase all talk to patternbuilderwp.com through this site. Pattern Builder is the only way to install anything from patternbuilderwp.com: the website shows collections and sends people here. Anonymous usage reporting, if you allow it, goes there too (see below). Terms: https://patternbuilderwp.com/terms/ — Privacy: https://patternbuilderwp.com/privacy/
 
 **Freemius** — the checkout for Pattern Builder Pro. Choosing Go Pro loads Freemius's checkout script (https://checkout.freemius.com/js/v1/) on the Pattern Builder screen and opens their checkout; nothing from Freemius loads anywhere else or before that click. Terms: https://freemius.com/terms/ — Privacy: https://freemius.com/privacy/
 
@@ -113,8 +113,8 @@ Yes, Pattern Builder provides a unified interface to manage both theme patterns 
 = 2.1.0 =
 * Patterns can carry images and fonts: find what the site already has, add a file, draw a placeholder, or install a self-hosted font family — and get back the exact reference to use
 * Font families install from the collection WordPress ships, with the files copied to your site and served from it rather than fetched from Google on every page view
-* Collections: every pattern on patternbuilderwp.com lives in exactly one collection. Every account has a private Personal; free accounts share the rest publicly, Pro builds collections in private
-* The Community tab is collections first: open one, save a single pattern, or save the whole collection to this site in one action, with one design-tokens step and a progress count
+* Collections: every pattern on patternbuilderwp.com lives in exactly one collection. Every account has a private Personal; Pro adds private collections of your own; publishing is by invitation, for Twenty Bellows and partner studios
+* The Directory tab is collections first: open one, save a single pattern, or save the whole collection to this site in one action, with one design-tokens step and a progress count
 * The Uploaded tab manages your collections — create, rename, describe, set the visibility, delete with everything in it — and uploads ask which collection when there is more than Personal
 * A page pattern brings the patterns it uses: uploading one uploads its sections into the same collection, installing one installs them first, and a pattern copied from somebody else's collection records where it came from
 * Patterns installed from a collection land under a local pattern category named for it
@@ -125,7 +125,7 @@ Yes, Pattern Builder provides a unified interface to manage both theme patterns 
 * render-pattern hands back preview URLs against the two bundled lab themes as well as the site's own; list-patterns reports the pattern categories the site has registered and every pattern's placement headers; get-design-system carries the definition of each block style variation the theme defines
 * add-block-style-variation says where a hover state goes, since a styles partial cannot hold one; refuses a variation for a block the site does not have
 * The authoring guides were checked against WordPress 7.1's own block library and corrected where they disagreed with it or with each other
-* Community patterns are browsed as an account: the Community tab asks you to sign in or create a free account first
+* Directory collections are browsed as an account: the Directory tab asks you to sign in or create a free account first
 * Creating an account from wp-admin now asks for a stronger password (eight characters, with an upper-case letter, a number and a symbol), asks whether we may email you news and offers, and sends a confirmation email
 * Forgot your password? The connect panel starts a reset; the link in the email finishes it on patternbuilderwp.com
 * Go Pro opens Freemius's checkout right on the Pattern Builder screen, and Pro is active the moment the purchase completes

--- a/readme.txt
+++ b/readme.txt
@@ -48,7 +48,7 @@ Pattern Builder transforms how you work with WordPress block patterns, providing
 **For Site Builders**
 * Build custom patterns without coding
 * Reuse patterns across multiple pages
-* Share patterns between sites
+* Carry patterns between sites
 * Maintain pattern library
 
 **For Agencies**

--- a/src/admin/PatternBrowser.js
+++ b/src/admin/PatternBrowser.js
@@ -42,7 +42,7 @@ const COLLECTIONS = [
 	{ key: THEME, label: __( 'Theme', 'pattern-builder' ) },
 	{ key: USER, label: __( 'User', 'pattern-builder' ) },
 	{ key: UPLOADED, label: __( 'Uploaded', 'pattern-builder' ) },
-	{ key: COMMUNITY, label: __( 'Community', 'pattern-builder' ) },
+	{ key: COMMUNITY, label: __( 'Directory', 'pattern-builder' ) },
 ];
 
 const CLOUD_COLLECTIONS = [ UPLOADED, COMMUNITY ];
@@ -120,7 +120,7 @@ function CategoryRail( { categories, active, onSelect } ) {
 
 /**
  * The browse screen: a header with the four collection tabs, a category rail scoped to the
- * active tab (none on Community, whose landing is its collections), a grid, and a details
+ * active tab (none on Directory, whose landing is its collections), a grid, and a details
  * sidebar that is always present.
  *
  * @param {Object}   props                Component props.

--- a/src/cloud/CloudBrowser.js
+++ b/src/cloud/CloudBrowser.js
@@ -577,7 +577,7 @@ export function CloudDetails( {
 				<Text variant="muted" size="12px">
 					{ source === 'library'
 						? __( 'Cloud pattern', 'pattern-builder' )
-						: __( 'Community pattern', 'pattern-builder' ) }
+						: __( 'Directory pattern', 'pattern-builder' ) }
 				</Text>
 
 				<Flex className="pattern-builder-details__actions" gap={ 2 }>
@@ -848,7 +848,7 @@ export function TokensList( { missing } ) {
 
 /**
  * The single-pattern save: a destination, then the tokens the site lacks, then the download
- * — as a hook, so the Community and Uploaded tabs share one flow and render its two modals
+ * — as a hook, so the Directory and Uploaded tabs share one flow and render its two modals
  * where they like.
  *
  * @param {Object}   options              Hook options.
@@ -1021,7 +1021,7 @@ export function useDownloadFlow( { source, onDownloaded } ) {
 
 /**
  * The cloud browsing surface: connect state and the account bar, then the Uploaded tab (the
- * account's collections and patterns) or the Community tab (public collections first, then
+ * account's collections and patterns) or the Directory tab (published collections first, then
  * patterns) — rendered in place of the local grid when a cloud tab is active.
  *
  * @param {Object}   props               Component props.
@@ -1187,11 +1187,11 @@ export function CloudBrowser( {
 					intro={
 						isLibrary
 							? __(
-									'Keep a pattern library on patternbuilderwp.com: upload patterns from this site, download them anywhere, and share collections with the community. Private by default, public if you want to share.',
+									'Keep a pattern library on patternbuilderwp.com: upload patterns from this site and install them on any other. Private, always.',
 									'pattern-builder'
 							  )
 							: __(
-									'Sign in to browse community collections and add them to this site. A free account you can use to keep your own patterns in the cloud too.',
+									'Sign in to browse the collections Twenty Bellows and partner studios publish, and add them to this site. A free account you can use to keep your own patterns in the cloud too.',
 									'pattern-builder'
 							  )
 					}
@@ -1201,7 +1201,7 @@ export function CloudBrowser( {
 									'Take your patterns with you',
 									'pattern-builder'
 							  )
-							: __( 'Community Collections', 'pattern-builder' )
+							: __( 'Curated Collections', 'pattern-builder' )
 					}
 					onConnected={ ( data ) => {
 						setStatus( data );
@@ -1300,7 +1300,7 @@ export function CloudBrowser( {
 				] }
 			>
 				{ __(
-					'Confirm your email address to upload patterns, install from the community, and go Pro. The link is in your inbox.',
+					'Confirm your email address to upload patterns, install from the directory, and go Pro. The link is in your inbox.',
 					'pattern-builder'
 				) }
 			</Notice>

--- a/src/cloud/CollectionView.js
+++ b/src/cloud/CollectionView.js
@@ -14,7 +14,7 @@ import { arrowLeft } from '@wordpress/icons';
 import { CloudCard } from './CloudBrowser';
 
 /**
- * One community collection opened: a header with its title, owner, description and count,
+ * One directory collection opened: a header with its title, owner, description and count,
  * "Save collection to this site", and then its patterns as the grid the rest of the browser
  * uses.
  *

--- a/src/cloud/CommunityTab.js
+++ b/src/cloud/CommunityTab.js
@@ -67,7 +67,7 @@ function Pagination( { page, pages, onPage } ) {
 }
 
 /**
- * The Community tab: collections first.
+ * The Directory tab: collections first.
  *
  * @param {Object}   props              Component props.
  * @param {Element}  props.chrome       The account bar and notices the shell renders.

--- a/src/cloud/UploadedTab.js
+++ b/src/cloud/UploadedTab.js
@@ -57,23 +57,28 @@ export function railFor( collections, personal ) {
 }
 
 /**
- * The New collection dialog: a name and a description, and the visibility only where the
- * account may choose.
+ * The New collection dialog: a name and a description, the visibility only for a
+ * publisher, and the upgrade in place of the form on an account without collections.
  *
  * @param {Object}   props            Component props.
- * @param {boolean}  props.canPrivate Whether the account may build in private.
+ * @param {boolean}  props.canCreate  Whether the account may have collections of its own.
+ * @param {boolean}  props.canPublish Whether the account may make one public.
  * @param {Function} props.onCreated  Called with the created collection.
  * @param {Function} props.onClose    Closes the dialog.
  * @param {Function} props.onGoPro    Opens the upgrade, or null.
  */
-function NewCollectionModal( { canPrivate, onCreated, onClose, onGoPro } ) {
+function NewCollectionModal( {
+	canCreate,
+	canPublish,
+	onCreated,
+	onClose,
+	onGoPro,
+} ) {
 	const [ name, setName ] = useState( '' );
 	const [ slug, setSlug ] = useState( '' );
 	const [ slugTouched, setSlugTouched ] = useState( false );
 	const [ description, setDescription ] = useState( '' );
-	const [ visibility, setVisibility ] = useState(
-		canPrivate ? 'private' : 'public'
-	);
+	const [ visibility, setVisibility ] = useState( 'private' );
 	const [ busy, setBusy ] = useState( false );
 	const [ error, setError ] = useState( '' );
 
@@ -94,7 +99,7 @@ function NewCollectionModal( { canPrivate, onCreated, onClose, onGoPro } ) {
 			name.trim(),
 			wanted,
 			description.trim(),
-			canPrivate ? visibility : ''
+			canPublish ? visibility : ''
 		)
 			.then( ( created ) => onCreated( created ) )
 			.catch( ( err ) => {
@@ -108,6 +113,35 @@ function NewCollectionModal( { canPrivate, onCreated, onClose, onGoPro } ) {
 				);
 			} );
 	};
+
+	if ( ! canCreate ) {
+		return (
+			<Modal
+				title={ __( 'New collection', 'pattern-builder' ) }
+				onRequestClose={ onClose }
+				className="pattern-builder-cloud__destination-modal"
+			>
+				<VStack spacing={ 3 }>
+					<p className="pattern-builder-cloud__meta">
+						{ __(
+							'Collections of your own are a Pattern Builder Pro feature: private, as many as you like, to organise work by client, by project or by kind. A free account keeps its patterns in Personal.',
+							'pattern-builder'
+						) }
+					</p>
+					<HStack spacing={ 2 } alignment="left">
+						{ onGoPro && (
+							<Button variant="primary" onClick={ onGoPro }>
+								{ __( 'Go Pro', 'pattern-builder' ) }
+							</Button>
+						) }
+						<Button variant="tertiary" onClick={ onClose }>
+							{ __( 'Not now', 'pattern-builder' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</Modal>
+		);
+	}
 
 	return (
 		<Modal
@@ -152,7 +186,7 @@ function NewCollectionModal( { canPrivate, onCreated, onClose, onGoPro } ) {
 						onChange={ setDescription }
 						rows={ 3 }
 					/>
-					{ canPrivate ? (
+					{ canPublish ? (
 						<SelectControl
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
@@ -170,27 +204,19 @@ function NewCollectionModal( { canPrivate, onCreated, onClose, onGoPro } ) {
 								{
 									value: 'public',
 									label: __(
-										'Public — listed in the community',
+										'Public — listed in the directory',
 										'pattern-builder'
 									),
 								},
 							] }
 						/>
 					) : (
-						<Notice status="info" isDismissible={ false }>
+						<Text variant="muted" size="12px">
 							{ __(
-								'This collection will be public: on a free account, every collection other than Personal is listed in the community as soon as its patterns pass the checks. Building a collection in private is a Pattern Builder Pro feature — or keep the work local.',
+								'Private: only you, on every site you connect.',
 								'pattern-builder'
 							) }
-							{ onGoPro && (
-								<>
-									{ ' ' }
-									<Button variant="link" onClick={ onGoPro }>
-										{ __( 'Go Pro', 'pattern-builder' ) }
-									</Button>
-								</>
-							) }
-						</Notice>
+						</Text>
 					) }
 					{ error && (
 						<Notice status="error" isDismissible={ false }>
@@ -312,16 +338,16 @@ function DeleteCollectionModal( { collection, onDeleted, onClose, onGoPro } ) {
 }
 
 /**
- * The selected collection's header: rename, describe, visibility (as the account may),
- * delete.
+ * The selected collection's header: rename, describe, visibility (for a publisher, or to
+ * take an inherited public collection private), delete.
  *
  * @param {Object}   props            Component props.
  * @param {Object}   props.collection The collection.
- * @param {boolean}  props.canPrivate Whether the account may make it private.
+ * @param {boolean}  props.canPublish Whether the account may make it public.
  * @param {Function} props.onChanged  Called with the updated collection.
  * @param {Function} props.onDelete   Opens the delete prompt.
  */
-function CollectionHeader( { collection, canPrivate, onChanged, onDelete } ) {
+function CollectionHeader( { collection, canPublish, onChanged, onDelete } ) {
 	const [ editing, setEditing ] = useState( false );
 	const [ name, setName ] = useState( collection.title );
 	const [ description, setDescription ] = useState(
@@ -360,14 +386,14 @@ function CollectionHeader( { collection, canPrivate, onChanged, onDelete } ) {
 
 	const visibilityOptions = [
 		{
-			value: 'public',
-			label: __( 'Public', 'pattern-builder' ),
-		},
-	];
-	if ( canPrivate || collection.visibility === 'private' ) {
-		visibilityOptions.unshift( {
 			value: 'private',
 			label: __( 'Private', 'pattern-builder' ),
+		},
+	];
+	if ( canPublish || collection.visibility === 'public' ) {
+		visibilityOptions.push( {
+			value: 'public',
+			label: __( 'Public', 'pattern-builder' ),
 		} );
 	}
 	if ( collection.visibility === 'premium' ) {
@@ -460,7 +486,7 @@ function CollectionHeader( { collection, canPrivate, onChanged, onDelete } ) {
 					className="pattern-builder-collection-view__actions"
 					wrap
 				>
-					{ ! collection.personal && (
+					{ ! collection.personal && visibilityOptions.length > 1 && (
 						<SelectControl
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
@@ -542,7 +568,8 @@ export function UploadedTab( {
 		onDownloaded,
 	} );
 
-	const canPrivate = !! status?.entitlements?.can_create_private;
+	const canCreate = !! status?.entitlements?.can_create_collections;
+	const canPublish = !! status?.entitlements?.can_publish;
 	const selectedId = Number( collection ) || 0;
 	const current = ( collections || [] ).find(
 		( item ) => item.id === selectedId
@@ -649,7 +676,7 @@ export function UploadedTab( {
 				{ status?.overPolicy && (
 					<Notice status="warning" isDismissible={ false }>
 						{ __(
-							'This account holds more than a free account may: a private collection, or a Personal over the cap. Nothing is taken away, and nothing more can be added to what is over. Make a collection public, delete, or go Pro.',
+							'This account holds more than a free account may: a collection other than Personal, or a Personal over the cap. Nothing is taken away, and nothing more can be added to what is over. Delete, or go Pro.',
 							'pattern-builder'
 						) }
 						{ onGoPro && (
@@ -676,7 +703,7 @@ export function UploadedTab( {
 				{ current && (
 					<CollectionHeader
 						collection={ current }
-						canPrivate={ canPrivate }
+						canPublish={ canPublish }
 						onChanged={ () => changed() }
 						onDelete={ () => setDeleting( current ) }
 					/>
@@ -749,7 +776,8 @@ export function UploadedTab( {
 
 				{ creating && (
 					<NewCollectionModal
-						canPrivate={ canPrivate }
+						canCreate={ canCreate }
+						canPublish={ canPublish }
 						onGoPro={ onGoPro }
 						onClose={ () => setCreating( false ) }
 						onCreated={ ( created ) => {

--- a/src/cloud/cloud.scss
+++ b/src/cloud/cloud.scss
@@ -166,7 +166,7 @@
 	}
 }
 
-// ---- Collections: tiles on the Community landing, and the opened view.
+// ---- Collections: tiles on the Directory landing, and the opened view.
 
 .pattern-builder-cloud__collections {
 	display: grid;

--- a/src/components/TelemetryPrompt.js
+++ b/src/components/TelemetryPrompt.js
@@ -16,7 +16,7 @@ import { setTelemetryConsent } from '../utils/telemetry';
 export function telemetryFacts() {
 	return [
 		__(
-			'What is sent: which parts of Pattern Builder are used (the browser opened, a pattern created, the community browsed), and the environment — WordPress, PHP and plugin versions, locale, theme, multisite.',
+			'What is sent: which parts of Pattern Builder are used (the browser opened, a pattern created, the directory browsed), and the environment — WordPress, PHP and plugin versions, locale, theme, multisite.',
 			'pattern-builder'
 		),
 		__(

--- a/tests/php/test-cloud-abilities.php
+++ b/tests/php/test-cloud-abilities.php
@@ -316,8 +316,8 @@ class Test_Cloud_Abilities extends WP_UnitTestCase {
 				if ( '/library/collections' === $path && 'POST' === $method ) {
 					return array(
 						'status'  => 403,
-						'code'    => 'pbwp_private_requires_pro',
-						'message' => 'Private collections are a Pattern Builder Pro feature.',
+						'code'    => 'pbwp_collections_require_pro',
+						'message' => 'Collections other than Personal are a Pattern Builder Pro feature.',
 						'data'    => array( 'status' => 403, 'upgrade_url' => 'https://patternbuilderwp.com/go-pro/' ),
 					);
 				}
@@ -328,7 +328,7 @@ class Test_Cloud_Abilities extends WP_UnitTestCase {
 		$result = $this->abilities->execute_create_collection( array( 'name' => 'Secret', 'slug' => 'secret', 'description' => 'Mine.' ) );
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'pbwp_private_requires_pro', $result->get_error_code() );
+		$this->assertSame( 'pbwp_collections_require_pro', $result->get_error_code() );
 		$this->assertSame( 'https://patternbuilderwp.com/go-pro/', $result->get_error_data()['upgrade_url'] );
 
 		$sent = json_decode( end( $this->seen )['body'], true );

--- a/tests/php/test-cloud-auth.php
+++ b/tests/php/test-cloud-auth.php
@@ -189,7 +189,7 @@ class Test_Cloud_Auth extends WP_UnitTestCase {
 		$this->assertSame( 403, $response->get_status() );
 	}
 
-	public function test_the_community_is_browsed_as_an_account() {
+	public function test_the_directory_is_browsed_as_an_account() {
 		$this->mock_service(
 			function () {
 				$this->fail( 'A disconnected site must not reach the service for the directory.' );

--- a/tests/php/test-cloud-collections.php
+++ b/tests/php/test-cloud-collections.php
@@ -157,7 +157,7 @@ class Test_Cloud_Collections extends WP_UnitTestCase {
 					'account'      => array( 'id' => 7, 'name' => 'Tester' ),
 					'tier'         => 'free',
 					'usage'        => array( 'stored' => 3 ),
-					'entitlements' => array( 'personal_cap' => 25, 'can_create_private' => false, 'fair_use' => array( 'patterns' => 2000, 'collections' => 200 ) ),
+					'entitlements' => array( 'personal_cap' => 25, 'can_create_collections' => false, 'can_publish' => false, 'fair_use' => array( 'patterns' => 2000, 'collections' => 200 ) ),
 					'personal'     => array( 'id' => 9, 'count' => 3, 'cap' => 25 ),
 					'over_policy'  => true,
 				);
@@ -167,7 +167,8 @@ class Test_Cloud_Collections extends WP_UnitTestCase {
 		$status = $this->request( 'GET', '/pattern-builder/v1/cloud/status' )->get_data();
 
 		$this->assertSame( 25, $status['entitlements']['personal_cap'] );
-		$this->assertFalse( $status['entitlements']['can_create_private'] );
+		$this->assertFalse( $status['entitlements']['can_create_collections'] );
+		$this->assertFalse( $status['entitlements']['can_publish'] );
 		$this->assertSame( array( 'id' => 9, 'count' => 3, 'cap' => 25 ), $status['personal'] );
 		$this->assertTrue( $status['overPolicy'] );
 	}
@@ -178,8 +179,8 @@ class Test_Cloud_Collections extends WP_UnitTestCase {
 				if ( '/library/collections' === $path && 'POST' === $method ) {
 					return array(
 						'status'  => 403,
-						'code'    => 'pbwp_private_requires_pro',
-						'message' => 'Private collections are a Pattern Builder Pro feature.',
+						'code'    => 'pbwp_collections_require_pro',
+						'message' => 'Collections other than Personal are a Pattern Builder Pro feature.',
 						'data'    => array( 'status' => 403, 'upgrade_url' => 'https://patternbuilderwp.com/go-pro/' ),
 					);
 				}
@@ -197,8 +198,8 @@ class Test_Cloud_Collections extends WP_UnitTestCase {
 
 		$created = $this->request( 'POST', '/pattern-builder/v1/cloud/library/collections', array( 'name' => 'Secret', 'visibility' => 'private' ) );
 		$this->assertSame( 403, $created->get_status() );
-		$this->assertSame( 'pbwp_private_requires_pro', $created->get_data()['code'] );
-		$this->assertSame( 'Private collections are a Pattern Builder Pro feature.', $created->get_data()['message'] );
+		$this->assertSame( 'pbwp_collections_require_pro', $created->get_data()['code'] );
+		$this->assertSame( 'Collections other than Personal are a Pattern Builder Pro feature.', $created->get_data()['message'] );
 		$this->assertSame( 'https://patternbuilderwp.com/go-pro/', $created->get_data()['data']['upgrade_url'] );
 
 	}


### PR DESCRIPTION
The plugin half of the launch model (D46 in the website repository): every collection is private unless a publisher makes it public, collections of your own are a Pro feature, and only Twenty Bellows and the partners it invites publish. Three commits.

## 1. The Uploaded tab, abilities and tests

- The tab reads `can_create_collections` and `can_publish` from the relayed entitlements (previously `can_create_private`).
- **New collection** shows the upgrade in place of the form on an account without collections; the form offers a visibility only to a publisher and says "Private: only you, on every site you connect" otherwise.
- The collection header's visibility control appears for a publisher, or to take an inherited public collection private, and never offers public to anyone else.
- The over-policy banner names the one way out that remains (delete, or go Pro).
- **Community → Directory.** Nothing in that tab is the community's any more, so the tab label, the connect panel, the tile label and the confirmation notice say Directory; the ability descriptions describe the directory and the create-collection refusal as the service now gives it. Component and file names, the `scope` value and the telemetry event name are unchanged.
- Tests follow the entitlement keys and the new refusal code.

## 2. Docs and readme

`docs/collections.md` describes the Directory tab, the create rule, the entitlement keys the status relays, the dialog on each kind of account and the lapsed-Pro way out; `docs/architecture.md` names the tabs as they are; the readme's collections lines and 2.1 changelog say what the tiers now are.

## 3. The sweep

A search of the whole plugin for the old vocabulary caught the telemetry facts, the disconnected refusal, a component comment, a test name, the readme's feature line, and the authoring guide's collections section — which told an agent that free accounts only make public collections. All say the directory now, and the guide says a collection is private unless a publisher has made it public.

## Verification

| | result |
|---|---|
| PHP suite | **425 / 426** — the one failure is `test_convert_theme_image_pattern_exports_assets`, identical at the base (the media pipeline this sandbox lacks, as CLAUDE.md documents) |
| `test:unit` | 104 passed |
| `lint:js` | clean on every file touched; the 34 pre-existing errors are all in `PatternDetailsPanel.js` and `PatternSyncedStatusPanel.js`, untouched |
| `phpcs` on the touched PHP | clean |
| `check:docs` | 491 identifiers, 0 unresolved |

Not changed here: the readme's tested-up-to line stays at 6.9 until the plugin has been checked against 7.0's content-only pattern editing and 7.1's public-exposure flag for abilities; that check is on the launch list in the website's business document.

Companion: Twenty-Bellows/patternbuilderwp.com#58 carries the rules, the price and the documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtSTgGTH5hSBWVLPCJohhi