### PR TITLE
2.1.0: version, tested up to 7.1, release notes, terms links in signup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Node 18+, PHP 7.4+ with Composer, Docker for `wp-env` and the PHP tests.
 | `npm run test:php` | PHP tests in wp-env (**Docker**). |
 | `npm run start` / `npm run stop` / `npm run clean` | wp-env lifecycle. |
 | `npm run plugin-test` | Build, zip and open in WP Playground. |
-| `npm run version-bump` | Bump the version everywhere it is tracked. |
+| `npm run version-bump` | Bump the patch version everywhere it is tracked; `npm run version-bump -- 2.2.0` sets one outright. |
 
 **No Docker?** The PHP suite runs host-native on SQLite: download WordPress and
 the `sqlite-database-integration` plugin, copy that plugin's `db.copy` to
@@ -173,4 +173,5 @@ correctly absent.
 ## Versioning
 
 The version is tracked in `pattern-builder.php`, `package.json` and
-`readme.txt`. `npm run version-bump` changes all three.
+`readme.txt`. `npm run version-bump` changes all three: the patch number by
+default, or the version given as its argument.

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -215,12 +215,14 @@ or name, never content. Events are buffered per request and posted once on
 `shutdown` to the service's public `/telemetry` relay, non-blocking; a lost
 batch is lost. The plugin loads no analytics script and names one service.
 
-## AI generation is not in the plugin
+## Nothing generates patterns, at either end
 
-The service still offers it (`/ai/generations`), but nothing here calls it: the
-create-pattern modal makes blank patterns only, and there is no
-`/cloud/generate` proxy. Pulled deliberately, to be reconsidered as a feature
-rather than carried half-wired.
+Neither the plugin nor the service runs a model; the service carried a pipeline
+for a while and has removed it (its decision log, D47). Generation is what an
+agent the user already runs does through the abilities — create, edit, upload,
+install, read the authoring guide — with the `pattern-author` and
+`design-reproduction` skills, on the user's own provider. The create-pattern
+modal makes blank patterns only, and there is no generate proxy.
 
 ## Code map
 

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -190,8 +190,10 @@ with an upper-case letter, a digit and a symbol — `passwordProblem()` mirrors
 it so the form says what is missing before the round trip), asks the marketing
 question as two buttons with neither preselected (a pre-checked box is not
 consent under GDPR and reads as opt-out to the wp.org review team; no answer
-relays as `no`), and leaves the account unverified until the emailed link is
-opened. *Forgot your password?* posts the address to
+relays as `no`), links the service's Terms of Service and Privacy Policy above
+the button (at the configured service's own `/terms/` and `/privacy/`, so a
+development service shows its own), and leaves the account unverified until
+the emailed link is opened. *Forgot your password?* posts the address to
 `/cloud/password/forgot`; the emailed link finishes the reset on
 patternbuilderwp.com, never here.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pattern-builder",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pattern-builder",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@wordpress/api-fetch": "^7.54.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pattern-builder",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "Manage patterns in WordPress",
 	"author": "twentybellows",
 	"main": "build/index.js",

--- a/pattern-builder.php
+++ b/pattern-builder.php
@@ -6,7 +6,7 @@
  * Description:       Manage Patterns in the WordPress Editor.
  * Requires at least: 6.8
  * Requires PHP:      7.4
- * Version: 2.0.0
+ * Version: 2.1.0
  * Author:            Twenty Bellows
  * Author URI:        https://twentybellows.com
  * License:           GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors:      twentybellows, pbking
 Tags:              block-patterns, patterns, block-editor, gutenberg, design
 Requires at least: 6.8
-Tested up to:      6.9
-Stable tag:        2.0.0
+Tested up to:      7.1
+Stable tag:        2.1.0
 Requires PHP:      7.4
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
@@ -111,25 +111,13 @@ Yes, Pattern Builder provides a unified interface to manage both theme patterns 
 == Changelog ==
 
 = 2.1.0 =
-* Patterns can carry images and fonts: find what the site already has, add a file, draw a placeholder, or install a self-hosted font family — and get back the exact reference to use
-* Font families install from the collection WordPress ships, with the files copied to your site and served from it rather than fetched from Google on every page view
-* Collections: every pattern on patternbuilderwp.com lives in exactly one collection. Every account has a private Personal; Pro adds private collections of your own; publishing is by invitation, for Twenty Bellows and partner studios
-* The Directory tab is collections first: open one, save a single pattern, or save the whole collection to this site in one action, with one design-tokens step and a progress count
-* The Uploaded tab manages your collections — create, rename, describe, set the visibility, delete with everything in it — and uploads ask which collection when there is more than Personal
-* A page pattern brings the patterns it uses: uploading one uploads its sections into the same collection, installing one installs them first, and a pattern copied from somebody else's collection records where it came from
-* Patterns installed from a collection land under a local pattern category named for it
-* Seven new abilities for agents: list and search collections and patterns, install a pattern or a collection, upload into a collection, create a private collection — all through the WordPress user's own connection
-* Agents can extend the design system rather than hard-code values into a pattern: a new ability adds colors, gradients, spacing sizes, font sizes and font families to the active theme's theme.json or to Site styles, leaving any token you already define alone
-* The create-pattern and update-pattern abilities now refuse, by name, what a server can see is wrong before anything is written: attribute JSON that does not parse, a heading or list contradicting its attributes, a block the site has not registered, a reference to a pattern that does not exist (or to the pattern itself), and a Pattern Overrides slot nothing can fill — so a page cannot be stored before the sections it references
-* A user pattern created by an agent keeps everything it was given: synced or not, description, categories and keywords
-* render-pattern hands back preview URLs against the two bundled lab themes as well as the site's own; list-patterns reports the pattern categories the site has registered and every pattern's placement headers; get-design-system carries the definition of each block style variation the theme defines
-* add-block-style-variation says where a hover state goes, since a styles partial cannot hold one; refuses a variation for a block the site does not have
-* The authoring guides were checked against WordPress 7.1's own block library and corrected where they disagreed with it or with each other
-* Directory collections are browsed as an account: the Directory tab asks you to sign in or create a free account first
-* Creating an account from wp-admin now asks for a stronger password (eight characters, with an upper-case letter, a number and a symbol), asks whether we may email you news and offers, and sends a confirmation email
-* Forgot your password? The connect panel starts a reset; the link in the email finishes it on patternbuilderwp.com
-* Go Pro opens Freemius's checkout right on the Pattern Builder screen, and Pro is active the moment the purchase completes
-* Opt-in anonymous usage reporting, asked once with Allow and No thanks, and never on by default
+* Cloud collections: sign in to a free patternbuilderwp.com account from Appearance → Pattern Builder and keep your patterns in a private Personal collection, on every site you connect; Pro adds private collections of your own
+* The Directory tab browses curated collections; save one pattern or a whole collection to this site, with the design tokens it needs, and the Uploaded tab manages your own collections
+* A page pattern travels with the patterns it references, uploading and installing them alongside it, and a copy records the pattern it came from
+* Images and fonts for patterns: find what the site has, add a file, draw a placeholder, or install a self-hosted font family, and get back the exact reference to use
+* Agents: seven cloud abilities, an ability that extends the theme's design tokens, create and update checks that refuse invalid markup by name, and authoring guides checked against WordPress 7.1
+* Accounts: stronger passwords, email confirmation, a password reset from the connect panel, and Go Pro through Freemius's checkout on the Pattern Builder screen
+* Opt-in anonymous usage reporting, asked once, never on by default
 
 = 2.0.0 =
 * Complete architectural overhaul: theme pattern files are now the single source of truth — no more database mirror posts, no more custom post type rows, and no more interception of the /wp/v2/blocks REST API

--- a/scripts/version-bump.js
+++ b/scripts/version-bump.js
@@ -11,7 +11,15 @@ const versionParts = currentVersion.split( '.' );
 const major = parseInt( versionParts[ 0 ] );
 const minor = parseInt( versionParts[ 1 ] );
 const patch = parseInt( versionParts[ 2 ] );
-const newVersion = `${ major }.${ minor }.${ patch + 1 }`;
+
+// `npm run version-bump` bumps the patch number; `npm run version-bump -- 2.2.0`
+// sets the version outright, for a minor or major release.
+const requested = process.argv[ 2 ];
+if ( requested !== undefined && ! /^\d+\.\d+\.\d+$/.test( requested ) ) {
+	console.error( `Not a version: ${ requested } (expected major.minor.patch)` );
+	process.exit( 1 );
+}
+const newVersion = requested || `${ major }.${ minor }.${ patch + 1 }`;
 
 console.log( `Bumping version from ${ currentVersion } to ${ newVersion }` );
 packageJson.version = newVersion;

--- a/src/cloud/CloudBrowser.js
+++ b/src/cloud/CloudBrowser.js
@@ -1,8 +1,14 @@
 import apiFetch from '@wordpress/api-fetch';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useState,
+	useEffect,
+	useCallback,
+} from '@wordpress/element';
 import {
 	Button,
+	ExternalLink,
 	Flex,
 	FlexItem,
 	Modal,
@@ -123,8 +129,9 @@ const PASSWORD_RULE = __(
  * @param {Function} props.onConnected Receives the fresh status payload.
  * @param {string}   props.intro       Why to connect, for this tab.
  * @param {string}   props.title       The title for the panel.
+ * @param {string}   props.serviceUrl  The service's origin, which the terms and privacy links point at.
  */
-function ConnectPanel( { onConnected, intro, title } ) {
+function ConnectPanel( { onConnected, intro, title, serviceUrl } ) {
 	const [ mode, setMode ] = useState( 'login' );
 	const [ email, setEmail ] = useState( '' );
 	const [ password, setPassword ] = useState( '' );
@@ -140,6 +147,10 @@ function ConnectPanel( { onConnected, intro, title } ) {
 
 	const isSignup = mode === 'signup';
 	const isForgot = mode === 'forgot';
+
+	// The terms and the privacy policy live on the service the site is configured
+	// for, so a development service shows its own; the public site is the fallback.
+	const legalBase = serviceUrl || 'https://patternbuilderwp.com';
 
 	const switchMode = ( next ) => {
 		setMode( next );
@@ -332,6 +343,28 @@ function ConnectPanel( { onConnected, intro, title } ) {
 							</Button>
 						</HStack>
 					</fieldset>
+				) }
+				{ isSignup && (
+					<p className="pattern-builder-cloud__legal">
+						{ createInterpolateElement(
+							__(
+								'By creating an account you agree to the <terms>Terms of Service</terms> and the <privacy>Privacy Policy</privacy>.',
+								'pattern-builder'
+							),
+							{
+								terms: (
+									<ExternalLink
+										href={ `${ legalBase }/terms/` }
+									/>
+								),
+								privacy: (
+									<ExternalLink
+										href={ `${ legalBase }/privacy/` }
+									/>
+								),
+							}
+						) }
+					</p>
 				) }
 				{ error && (
 					<Notice status="error" isDismissible={ false }>
@@ -1184,6 +1217,7 @@ export function CloudBrowser( {
 		return (
 			<main className="pattern-builder-browser__main">
 				<ConnectPanel
+					serviceUrl={ status.serviceUrl }
 					intro={
 						isLibrary
 							? __(

--- a/src/cloud/cloud.scss
+++ b/src/cloud/cloud.scss
@@ -145,6 +145,12 @@
 	font-size: 12px;
 }
 
+.pattern-builder-cloud__legal {
+	margin: 0;
+	color: #50575e;
+	font-size: 12px;
+}
+
 .pattern-builder-cloud__verify {
 	margin: 0 0 12px;
 }


### PR DESCRIPTION
## Summary

Three commits, one per change:

- **Version 2.1.0** in `pattern-builder.php`, `package.json` (and the lockfile's root entry) and readme.txt's Stable tag; `Tested up to: 7.1`; the 2.1.0 changelog condensed to a seven-line outline. `scripts/version-bump.js` now takes a version as its argument (`npm run version-bump -- 2.2.0`), since it could only ever step the patch number; CLAUDE.md says so.
- **`docs/cloud.md`**: the service has removed its generation pipeline (its D47), so the section now says nothing generates patterns at either end. An agent the user runs does that through the abilities and the `pattern-author` and `design-reproduction` skills.
- **The signup form** links the Terms of Service and the Privacy Policy above the button, at the configured service's own `/terms/` and `/privacy/`, so a development service shows its own.

## Verification

- `npm run test:unit`: 104 tests passed
- `wp-scripts lint-js` and `lint-style` clean on the touched files
- `npm run check:docs`: 493 identifiers, 0 unresolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtSTgGTH5hSBWVLPCJohhi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtSTgGTH5hSBWVLPCJohhi)_